### PR TITLE
Make content in variable explorer inline with Spyder

### DIFF
--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -55,7 +55,7 @@ def _getshapeof(x):
     if np and isinstance(x, np.ndarray):
         shape = " x ".join([str(i) for i in x.shape])
         return "Array [%s]" %  shape
-    return str(x)[:200]
+    return None
 
 
 def _getcontentof(x):
@@ -93,7 +93,10 @@ def _var_dic_list():
    
     public static getScript(lang:string):Promise<Languages.LanguageModel>{
         return new Promise(function(resolve, reject) {
-            if (lang in Languages.scripts){
+            if (lang.startsWith("python")){
+                resolve(Languages.scripts["python"] );
+            }
+            else if (lang in Languages.scripts){
                 resolve(Languages.scripts[lang] );
             }else{
                 reject("Language " + lang + " not supported yet!");

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -7,56 +7,88 @@ namespace Languages{
     }
 }
 
+
 export
 abstract class Languages{
     /**
      * Init and query script for supported languages.
      */
-   static scripts: { [index: string]: Languages.LanguageModel } = {
-           "python3" : { initScript : `import json\n
-from sys import getsizeof\n
+    static py_script: string = `import json
+from sys import getsizeof
 
-from IPython import get_ipython\n
-from IPython.core.magics.namespace import NamespaceMagics\n
+from IPython import get_ipython
+from IPython.core.magics.namespace import NamespaceMagics
 
-_nms = NamespaceMagics()\n
-_Jupyter = get_ipython()\n
-_nms.shell = _Jupyter.kernel.shell\n
+_nms = NamespaceMagics()
+_Jupyter = get_ipython()
+_nms.shell = _Jupyter.kernel.shell
 
-try:\n
-    import numpy as np  # noqa: F401\n
-except ImportError:\n
-    pass\n
+try:
+    import numpy as np  # noqa: F401
+except ImportError:
+    np = None
 
-
-def _getsizeof(x):\n
-    # return the size of variable x. Amended version of sys.getsizeof\n
-    # which also supports ndarray, Series and DataFrame\n
-    if type(x).__name__ in ['ndarray', 'Series']:\n
-        return x.nbytes\n
-    elif type(x).__name__ == 'DataFrame':\n
-        return x.memory_usage().sum()\n
-    else:\n
-        return getsizeof(x)\n
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
 
 
-def _getshapeof(x):\n
-    # returns the shape of x if it has one\n
-    # returns None otherwise - might want to return an empty string for an empty collum\n
-    try:\n
-        return x.shape\n
-    except AttributeError:  # x does not have a shape\n
-        return None\n
+def _getsizeof(x):
+    # return the size of variable x. Amended version of sys.getsizeof
+    # which also supports ndarray, Series and DataFrame
+    if type(x).__name__ in ['ndarray', 'Series']:
+        return x.nbytes
+    elif type(x).__name__ == 'DataFrame':
+        return x.memory_usage().sum()
+    else:
+        return getsizeof(x)
 
 
-def _var_dic_list():\n
-    types_to_exclude = ['module', 'function', 'builtin_function_or_method','instance', '_Feature', 'type', 'ufunc']\n
-    values = _nms.who_ls()\n
-    vardic = [{'varName': v, 'varType': type(eval(v)).__name__, 'varSize': str(_getsizeof(eval(v))), 'varShape': str(_getshapeof(eval(v))) if _getshapeof(eval(v)) else '', 'varContent': str(eval(v))[:200]}  # noqa\n
-        for v in values if ((str(eval(v))[0] != "<") or (isinstance(eval(v), str)))] #Prevent showing classes, modules etc.\n
-    return json.dumps(vardic)\n
-                        `,
-                        queryCommand : "_var_dic_list()"},
+def _getshapeof(x):
+    # returns content in a friendly way for python variables
+    # pandas and numpy
+    if pd and isinstance(x, pd.DataFrame):
+        return "DataFrame [%d rows x %d cols]" % x.shape
+    if pd and isinstance(x, pd.Series):
+        return "Series [%d rows]" % x.shape
+    if np and isinstance(x, np.ndarray):
+        shape = " x ".join([str(i) for i in x.shape])
+        return "Array [%s]" %  shape
+    return str(x)[:200]
+
+
+def _getcontentof(x):
+    # returns content in a friendly way for python variables
+    # pandas and numpy
+    if pd and isinstance(x, pd.DataFrame):
+        colnames = ', '.join(list(x.columns))
+        return "Column names: %s" % colnames
+    if pd and isinstance(x, pd.Series):
+        return "Series [%d rows]" % x.shape
+    if np and isinstance(x, np.ndarray):
+        return x.__repr__()
+    return str(x)[:200]
+
+
+def _var_dic_list():
+    types_to_exclude = ['module', 'function', 'builtin_function_or_method','instance', '_Feature', 'type', 'ufunc']
+    values = _nms.who_ls()
+    vardic = [{'varName': v, 
+               'varType': type(eval(v)).__name__, 
+               'varSize': str(_getsizeof(eval(v))), 
+               'varShape': str(_getshapeof(eval(v))) if _getshapeof(eval(v)) else '', 
+               'varContent': str(_getcontentof(eval(v)))}  # noqa
+        for v in values if ((str(eval(v))[0] != "<") or (isinstance(eval(v), str)))] #Prevent showing classes, modules etc.
+    return json.dumps(vardic)
+`;
+    static scripts: { [index: string]: Languages.LanguageModel } = {
+           "python3" : { initScript : Languages.py_script,
+    queryCommand : "_var_dic_list()"},
+"python2" : { initScript : Languages.py_script,
+    queryCommand : "_var_dic_list()"},
+"python" : { initScript : Languages.py_script,
+    queryCommand : "_var_dic_list()"}
                 };
    
     public static getScript(lang:string):Promise<Languages.LanguageModel>{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "target": "ES5",
     "outDir": "./lib",
-    "lib": ["ES5", "ES2015.Promise", "DOM"],
+    "lib": ["ES5", "ES2015.Promise", "DOM", "es2015.core"],
     "types": []
   },
   "include": ["src/*"]


### PR DESCRIPTION
This sort of address #3 through the patterns used in the variable explorer in Spyder.

For `numpy.ndarrays`, `__repr__` is used, whilst for Pandas, we just list the columns. The Shape code is adapted from [Rodeo](https://github.com/yhat/rodeo/blob/0b4a9ed5acf052fa9e2eca9427263b5dc44c187d/src/node/kernels/python/langs/python-patch.py): 

Screenshot is shown below

![image](https://user-images.githubusercontent.com/2498638/42384087-67e52488-817c-11e8-8742-e594bc3e0749.png)




