### PR TITLE
Numpy prettify

### DIFF
--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -13,52 +13,68 @@ export
     /**
      * Init and query script for supported languages.
      */
+
+    static py_script: string = `import json
+from sys import getsizeof
+
+from IPython import get_ipythonfrom IPython.core.magics.namespace import NamespaceMagics_jupyterlab_variableinspector_nms = NamespaceMagics()
+
+_jupyterlab_variableinspector_Jupyter = get_ipython()
+_jupyterlab_variableinspector_nms.shell = _jupyterlab_variableinspector_Jupyter.kernel.shell
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
+
+def _jupyterlab_variableinspector_getsizeof(x):
+    if type(x).__name__ in ['ndarray', 'Series']:
+        return x.nbytes
+    elif type(x).__name__ == 'DataFrame':
+        return x.memory_usage().sum()
+    else:
+        return getsizeof(x)
+
+def _jupyterlab_variableinspector_getshapeof(x):
+    if pd and isinstance(x, pd.DataFrame):
+        return "DataFrame [%d rows x %d cols]" % x.shape
+    if pd and isinstance(x, pd.Series):
+        return "Series [%d rows]" % x.shape
+    if np and isinstance(x, np.ndarray):
+        shape = " x ".join([str(i) for i in x.shape])
+        return "Array [%s]" %  shape
+    return None
+
+def _jupyterlab_variableinspector_dict_list():
+    values = _jupyterlab_variableinspector_nms.who_ls()
+    vardic = [{'varName': v, 'varType': type(eval(v)).__name__, 'varSize': str(_jupyterlab_variableinspector_getsizeof(eval(v))), 'varShape': str(_jupyterlab_variableinspector_getshapeof(eval(v))) if _jupyterlab_variableinspector_getshapeof(eval(v)) else '', 'varContent': str(eval(v))[:200], 'isMatrix': True if type(eval(v)).__name__ in ["DataFrame", "ndarray", "Series"] else False}  # noqa
+            for v in values if ((str(eval(v))[0] != "<") or (isinstance(eval(v), str)))]
+    return json.dumps(vardic)
+
+def _jupyterlab_variableinspector_getmatrixcontent(x):
+    if np and pd and type(x).__name__ in ["Series", "DataFrame"]:
+        x.columns = x.columns.map(str)
+        response = {"schema": pd.io.json.build_table_schema(x),"data": x.to_dict(orient="records")}
+        return json.dumps(response,default=_jupyterlab_variableinspector_default)
+    elif np and pd and type(x).__name__ in ["ndarray"]:
+        df = pd.DataFrame(x)
+        df.columns = df.columns.map(str)
+        response = {"schema": pd.io.json.build_table_schema(df), "data": df.to_dict(orient="records")}
+        return json.dumps(response,default=_jupyterlab_variableinspector_default)
+
+def _jupyterlab_variableinspector_default(o):
+    if isinstance(o, np.number): return int(o)  
+    raise TypeError
+`;
+    
     static scripts: { [index: string]: Languages.LanguageModel } = {
         "python3": {
-            initScript:
-            `import json\n
-import numpy as np\n
-import pandas as pd\n
-from sys import getsizeof\n
-from IPython import get_ipython\nfrom IPython.core.magics.namespace import NamespaceMagics\n_jupyterlab_variableinspector_nms = NamespaceMagics()\n
-_jupyterlab_variableinspector_Jupyter = get_ipython()\n
-_jupyterlab_variableinspector_nms.shell = _jupyterlab_variableinspector_Jupyter.kernel.shell\n
-try:\n
-\timport numpy as np  # noqa: F401\n
-except ImportError:\n
-\tpass\n
-def _jupyterlab_variableinspector_getsizeof(x):\n
-\tif type(x).__name__ in ['ndarray', 'Series']:\n
-\t\treturn x.nbytes\n
-\telif type(x).__name__ == 'DataFrame':\n
-\t\treturn x.memory_usage().sum()\n
-\telse:\n
-\t\treturn getsizeof(x)\n
-\t\n
-def _jupyterlab_variableinspector_getshapeof(x):\n
-\ttry:\n
-\t\treturn x.shape\n
-\texcept AttributeError:  # x does not have a shape\n
-\t\treturn None\n
-\t\n
-def _jupyterlab_variableinspector_dict_list():\n
-\tvalues = _jupyterlab_variableinspector_nms.who_ls()\n
-\tvardic = [{'varName': v, 'varType': type(eval(v)).__name__, 'varSize': str(_jupyterlab_variableinspector_getsizeof(eval(v))), 'varShape': str(_jupyterlab_variableinspector_getshapeof(eval(v))) if _jupyterlab_variableinspector_getshapeof(eval(v)) else '', 'varContent': str(eval(v))[:200], 'isMatrix': True if type(eval(v)).__name__ in ["DataFrame", "ndarray", "Series"] else False}  # noqa\n\n
-\t\t\tfor v in values if ((str(eval(v))[0] != "<") or (isinstance(eval(v), str)))]\n\n
-\treturn json.dumps(vardic)\n
-def _jupyterlab_variableinspector_getmatrixcontent(x):\n
-\tif type(x).__name__ in ["Series", "DataFrame"]:\n
-\t\tx.columns = x.columns.map(str)\n
-\t\tresponse = {"schema": pd.io.json.build_table_schema(x),"data": x.to_dict(orient="records")}\n
-\t\treturn json.dumps(response,default=_jupyterlab_variableinspector_default)\n
-\telif type(x).__name__ in ["ndarray"]:\n
-\t\tdf = pd.DataFrame(x)\n
-\t\tdf.columns = df.columns.map(str)\n
-\t\tresponse = {"schema": pd.io.json.build_table_schema(df), "data": df.to_dict(orient="records")}\n
-\t\treturn json.dumps(response,default=_jupyterlab_variableinspector_default)\n
-def _jupyterlab_variableinspector_default(o):\n
-\tif isinstance(o, np.number): return int(o)  \n
-\traise TypeError`,
+            initScript: Languages.py_script,
             queryCommand: "_jupyterlab_variableinspector_dict_list()",
             matrixQueryCommand: "_jupyterlab_variableinspector_getmatrixcontent"
         }

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -64,14 +64,15 @@ def _jupyterlab_variableinspector_getcontentof(x):
         return x.__repr__()
     return str(x)[:200]
 
+
 def _jupyterlab_variableinspector_dict_list():
     values = _jupyterlab_variableinspector_nms.who_ls()
-    vardic = [{'varName': v, 'varType': type(eval(v)).__name__, 
-    'varSize': str(_jupyterlab_variableinspector_getsizeof(eval(v))), 
-    'varShape': str(_jupyterlab_variableinspector_getshapeof(eval(v))) if _jupyterlab_variableinspector_getshapeof(eval(v)) else '', 
-    'varContent': str(_jupyterlab_variableinspector_getcontentof(eval(v))), 
-    'isMatrix': True if type(eval(v)).__name__ in ["DataFrame", "ndarray", "Series"] else False}
-            for v in values if ((str(eval(v))[0] != "<") or (isinstance(eval(v), str)))]
+    vardic = [{'varName': _v, 'varType': type(eval(_v)).__name__, 
+    'varSize': str(_jupyterlab_variableinspector_getsizeof(eval(_v))), 
+    'varShape': str(_jupyterlab_variableinspector_getshapeof(eval(_v))) if _jupyterlab_variableinspector_getshapeof(eval(_v)) else '', 
+    'varContent': str(_jupyterlab_variableinspector_getcontentof(eval(_v))), 
+    'isMatrix': True if type(eval(_v)).__name__ in ["DataFrame", "ndarray", "Series"] else False}
+            for _v in values if ((str(eval(_v))[0] != "<") or (isinstance(eval(_v), str)))]
     return json.dumps(vardic)
 
 def _jupyterlab_variableinspector_getmatrixcontent(x):

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -17,8 +17,10 @@ export
     static py_script: string = `import json
 from sys import getsizeof
 
-from IPython import get_ipythonfrom IPython.core.magics.namespace import NamespaceMagics_jupyterlab_variableinspector_nms = NamespaceMagics()
+from IPython import get_ipython
+from IPython.core.magics.namespace import NamespaceMagics
 
+_jupyterlab_variableinspector_nms = NamespaceMagics()
 _jupyterlab_variableinspector_Jupyter = get_ipython()
 _jupyterlab_variableinspector_nms.shell = _jupyterlab_variableinspector_Jupyter.kernel.shell
 

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -50,9 +50,25 @@ def _jupyterlab_variableinspector_getshapeof(x):
         return "Array [%s]" %  shape
     return None
 
+def _jupyterlab_variableinspector_getcontentof(x):
+    # returns content in a friendly way for python variables
+    # pandas and numpy
+    if pd and isinstance(x, pd.DataFrame):
+        colnames = ', '.join(list(x.columns))
+        return "Column names: %s" % colnames
+    if pd and isinstance(x, pd.Series):
+        return "Series [%d rows]" % x.shape
+    if np and isinstance(x, np.ndarray):
+        return x.__repr__()
+    return str(x)[:200]
+
 def _jupyterlab_variableinspector_dict_list():
     values = _jupyterlab_variableinspector_nms.who_ls()
-    vardic = [{'varName': v, 'varType': type(eval(v)).__name__, 'varSize': str(_jupyterlab_variableinspector_getsizeof(eval(v))), 'varShape': str(_jupyterlab_variableinspector_getshapeof(eval(v))) if _jupyterlab_variableinspector_getshapeof(eval(v)) else '', 'varContent': str(eval(v))[:200], 'isMatrix': True if type(eval(v)).__name__ in ["DataFrame", "ndarray", "Series"] else False}  # noqa
+    vardic = [{'varName': v, 'varType': type(eval(v)).__name__, 
+    'varSize': str(_jupyterlab_variableinspector_getsizeof(eval(v))), 
+    'varShape': str(_jupyterlab_variableinspector_getshapeof(eval(v))) if _jupyterlab_variableinspector_getshapeof(eval(v)) else '', 
+    'varContent': str(_jupyterlab_variableinspector_getcontentof(eval(v))), 
+    'isMatrix': True if type(eval(v)).__name__ in ["DataFrame", "ndarray", "Series"] else False}
             for v in values if ((str(eval(v))[0] != "<") or (isinstance(eval(v), str)))]
     return json.dumps(vardic)
 


### PR DESCRIPTION
This PR also cleans up the inspector code a bit. (See #3) uses `__repr__` which is in line with how Spyder approaches it. Also uses conventions in Spyder and Rodeo for DataFrame handling + np.ndarray

We also cannot assume that pandas and numpy is in the environment by default which may cause it to fail as well.

![image](https://user-images.githubusercontent.com/2498638/42388061-a81e017c-8187-11e8-8e31-cc151d580ee1.png)
