### PR TITLE
fixing kernel name issue when you create multiple envs

### DIFF
--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -14,7 +14,7 @@ export
      * Init and query script for supported languages.
      */
     static scripts: { [index: string]: Languages.LanguageModel } = {
-        "python3": {
+        "python": {
             initScript:
             `import json\n
 import numpy as np\n

--- a/src/kernelconnector.ts
+++ b/src/kernelconnector.ts
@@ -30,7 +30,7 @@ export
 
 
     get kerneltype(): string {
-        return this._session.kernel.name;
+        return this._session.kernel.info.language_info.name;
     }
 
 
@@ -38,7 +38,7 @@ export
      *  A Promise that is fulfilled when the session associated w/ the connector is ready.
      */
     get ready(): Promise<void> {
-        return this._session.ready;
+        return this._session.kernel.ready;
     }
 
     /**


### PR DESCRIPTION
Now works with Python 2.

Address #15 and also extends #5 with Python 2 support (so long as the python script is python 3 and python 2 compatible)

<img width="937" alt="screen shot 2018-07-08 at 12 40 35 pm" src="https://user-images.githubusercontent.com/2498638/42416247-a8725d6e-82ac-11e8-82a8-974cdd8bd047.png">
