### PR TITLE
Fix/startup

### DIFF
--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -92,7 +92,7 @@ def _jupyterlab_variableinspector_default(o):
 `;
     
     static scripts: { [index: string]: Languages.LanguageModel } = {
-        "python": {
+        "python3": {
             initScript: Languages.py_script,
             queryCommand: "_jupyterlab_variableinspector_dict_list()",
             matrixQueryCommand: "_jupyterlab_variableinspector_getmatrixcontent"

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -56,7 +56,7 @@ def _jupyterlab_variableinspector_getcontentof(x):
     # returns content in a friendly way for python variables
     # pandas and numpy
     if pd and isinstance(x, pd.DataFrame):
-        colnames = ', '.join(list(x.columns))
+        colnames = ', '.join([str(c) for c  in x.columns])
         return "Column names: %s" % colnames
     if pd and isinstance(x, pd.Series):
         return "Series [%d rows]" % x.shape

--- a/src/kernelconnector.ts
+++ b/src/kernelconnector.ts
@@ -30,7 +30,7 @@ export
 
 
     get kerneltype(): string {
-        return this._session.kernel.info.language_info.name;
+        return this._session.kernel.name;
     }
 
 
@@ -38,7 +38,7 @@ export
      *  A Promise that is fulfilled when the session associated w/ the connector is ready.
      */
     get ready(): Promise<void> {
-        return this._session.kernel.ready;
+        return this._session.ready;
     }
 
     /**


### PR DESCRIPTION
Reverting merge #17 that can break the initialization of the inspector.
Fixes bug where pd.DataFrames w/ integer column names result in execution error.