### PR TITLE
adding keras/tf and Spark support

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -101,9 +101,9 @@ export
      * Performs an inspection of the specified matrix.
      */
 
-    public performMatrixInspection( varName: string ): Promise<DataModel> {
+    public performMatrixInspection( varName: string, maxRows=100000 ): Promise<DataModel> {
         let request: KernelMessage.IExecuteRequest = {
-            code: this._matrixQueryCommand + "(" + varName + ")",
+            code: this._matrixQueryCommand + "(" + varName + ", " + maxRows + ")",
             stop_on_error: false,
             store_history: false,
         };

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -24,8 +24,6 @@ _jupyterlab_variableinspector_nms = NamespaceMagics()
 _jupyterlab_variableinspector_Jupyter = get_ipython()
 _jupyterlab_variableinspector_nms.shell = _jupyterlab_variableinspector_Jupyter.kernel.shell
 
-_jupyterlab_variableinspector_maxrows = 10**6 # None for view all
-
 try:
     import numpy as np
 except ImportError:
@@ -110,7 +108,7 @@ def _jupyterlab_variableinspector_is_matrix(x):
     return False
 
 
-def _jupyterlab_variableinspector_dict_list():
+def _jupyterlab_variableinspector_dict_list(max_rows):
     def keep_cond(v):
         if isinstance(eval(v), str):
             return True
@@ -135,30 +133,10 @@ def _jupyterlab_variableinspector_dict_list():
     return json.dumps(vardic)
 
 
-def _jupyterlab_variableinspector_getmatrixcontent(x):
-    def get_np_threshold():
-        if np and np.get_printoptions()['threshold'] != 1000: # this is the default
-            return np.get_printoptions()['threshold']
-        return _jupyterlab_variableinspector_maxrows
+def _jupyterlab_variableinspector_getmatrixcontent(x, max_rows=10000):
     
-    def get_pd_threshold():
-        if pd and pd.get_option('max_rows') != 60:
-            return pd.get_option('max_rows')
-        return _jupyterlab_variableinspector_maxrows
-    
-    def get_threshold(np_thres, pd_thres):
-        if np_thres is None:
-            return pd_thres
-        elif pd_thres is None:
-            return np_thres
-        elif np_thres < 0 or pd_thres < 0:
-            return None
-        else:
-            return max(np_thres, pd_thres)
-        
-    np_threshold = get_np_threshold()
-    pd_threshold = get_pd_threshold()
-    threshold = get_threshold(np_threshold, pd_threshold)
+    # to do: add something to handle this in the future
+    threshold = max_rows
 
     if pd and pyspark and isinstance(x, pyspark.sql.DataFrame):
         df = x.limit(threshold).toPandas()

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -81,7 +81,7 @@ def _jupyterlab_variableinspector_getcontentof(x):
     # returns content in a friendly way for python variables
     # pandas and numpy
     if pd and isinstance(x, pd.DataFrame):
-        colnames = ', '.join(list(x.columns))
+        colnames = ', '.join([str(c) for c  in x.columns])
         return "Column names: %s" % colnames
     if pd and isinstance(x, pd.Series):
         return "Series [%d rows]" % x.shape

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -108,7 +108,7 @@ def _jupyterlab_variableinspector_is_matrix(x):
     return False
 
 
-def _jupyterlab_variableinspector_dict_list(max_rows):
+def _jupyterlab_variableinspector_dict_list():
     def keep_cond(v):
         if isinstance(eval(v), str):
             return True

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -16,13 +16,15 @@ export
 
     static py_script: string = `import json
 from sys import getsizeof
-
 from IPython import get_ipython
 from IPython.core.magics.namespace import NamespaceMagics
+
 
 _jupyterlab_variableinspector_nms = NamespaceMagics()
 _jupyterlab_variableinspector_Jupyter = get_ipython()
 _jupyterlab_variableinspector_nms.shell = _jupyterlab_variableinspector_Jupyter.kernel.shell
+
+_jupyterlab_variableinspector_maxrows = 10**6 # None for view all
 
 try:
     import numpy as np
@@ -34,13 +36,30 @@ try:
 except ImportError:
     pd = None
 
+try:
+    import pyspark
+except ImportError:
+    pyspark = None
+
+try:
+    import tensorflow as tf
+    import keras.backend as K
+except ImportError:
+    tf = None
+
+
 def _jupyterlab_variableinspector_getsizeof(x):
     if type(x).__name__ in ['ndarray', 'Series']:
         return x.nbytes
-    elif type(x).__name__ == 'DataFrame':
+    elif pyspark and isinstance(x, pyspark.sql.DataFrame):
+        return "?"
+    elif tf and isinstance(x, tf.Variable):
+        return "?"
+    elif pd and type(x).__name__ == 'DataFrame':
         return x.memory_usage().sum()
     else:
         return getsizeof(x)
+
 
 def _jupyterlab_variableinspector_getshapeof(x):
     if pd and isinstance(x, pd.DataFrame):
@@ -50,41 +69,116 @@ def _jupyterlab_variableinspector_getshapeof(x):
     if np and isinstance(x, np.ndarray):
         shape = " x ".join([str(i) for i in x.shape])
         return "Array [%s]" %  shape
+    if pyspark and isinstance(x, pyspark.sql.DataFrame):
+        return "Spark DataFrame [? rows x %d cols]" % len(x.columns)
+    if tf and isinstance(x, tf.Variable):
+        shape = " x ".join([str(int(i)) for i in x.shape])
+        return "Tensorflow Variable [%s]" % shape
     return None
+
 
 def _jupyterlab_variableinspector_getcontentof(x):
     # returns content in a friendly way for python variables
     # pandas and numpy
     if pd and isinstance(x, pd.DataFrame):
-        colnames = ', '.join([str(c) for c  in x.columns])
+        colnames = ', '.join(list(x.columns))
         return "Column names: %s" % colnames
     if pd and isinstance(x, pd.Series):
         return "Series [%d rows]" % x.shape
     if np and isinstance(x, np.ndarray):
         return x.__repr__()
+    if pyspark and isinstance(x, pyspark.sql.DataFrame):
+        return x.__repr__()
+    if tf and isinstance(x, tf.Variable):
+        # This is to allow tf.Variable.__repr__ to appear
+        return x.__repr__().replace("<", "").replace(">", "").strip()
     return str(x)[:200]
 
 
+def _jupyterlab_variableinspector_is_matrix(x):
+    # True if type(x).__name__ in ["DataFrame", "ndarray", "Series"] else False
+    if pd and isinstance(x, pd.DataFrame):
+        return True
+    if pd and isinstance(x, pd.Series):
+        return True
+    if np and isinstance(x, np.ndarray):
+        return True
+    if pyspark and isinstance(x, pyspark.sql.DataFrame):
+        return True
+    if tf and isinstance(x, tf.Variable):
+        return True
+    return False
+
+
 def _jupyterlab_variableinspector_dict_list():
+    def keep_cond(v):
+        if isinstance(eval(v), str):
+            return True
+        if tf and isinstance(eval(v), tf.Variable):
+            return True
+        if str(eval(v))[0] == "<":
+            return False
+        if  v in ['np', 'pd', 'pyspark', 'tf']:
+            return eval(v) is not None
+        if str(eval(v)).startswith("_Feature"):
+            # removes tf/keras objects
+            return False
+        return True
     values = _jupyterlab_variableinspector_nms.who_ls()
-    vardic = [{'varName': _v, 'varType': type(eval(_v)).__name__, 
+    vardic = [{'varName': _v, 
+    'varType': type(eval(_v)).__name__, 
     'varSize': str(_jupyterlab_variableinspector_getsizeof(eval(_v))), 
     'varShape': str(_jupyterlab_variableinspector_getshapeof(eval(_v))) if _jupyterlab_variableinspector_getshapeof(eval(_v)) else '', 
     'varContent': str(_jupyterlab_variableinspector_getcontentof(eval(_v))), 
-    'isMatrix': True if type(eval(_v)).__name__ in ["DataFrame", "ndarray", "Series"] else False}
-            for _v in values if ((str(eval(_v))[0] != "<") or (isinstance(eval(_v), str)))]
+    'isMatrix': _jupyterlab_variableinspector_is_matrix(eval(_v))}
+            for _v in values if keep_cond(_v)]
     return json.dumps(vardic)
 
+
 def _jupyterlab_variableinspector_getmatrixcontent(x):
-    if np and pd and type(x).__name__ in ["Series", "DataFrame"]:
+    def get_np_threshold():
+        if np and np.get_printoptions()['threshold'] != 1000: # this is the default
+            return np.get_printoptions()['threshold']
+        return _jupyterlab_variableinspector_maxrows
+    
+    def get_pd_threshold():
+        if pd and pd.get_option('max_rows') != 60:
+            return pd.get_option('max_rows')
+        return _jupyterlab_variableinspector_maxrows
+    
+    def get_threshold(np_thres, pd_thres):
+        if np_thres is None:
+            return pd_thres
+        elif pd_thres is None:
+            return np_thres
+        elif np_thres < 0 or pd_thres < 0:
+            return None
+        else:
+            return max(np_thres, pd_thres)
+        
+    np_threshold = get_np_threshold()
+    pd_threshold = get_pd_threshold()
+    threshold = get_threshold(np_threshold, pd_threshold)
+
+    if pd and pyspark and isinstance(x, pyspark.sql.DataFrame):
+        df = x.limit(threshold).toPandas()
+        return _jupyterlab_variableinspector_getmatrixcontent(df.copy())
+    elif np and pd and type(x).__name__ in ["Series", "DataFrame"]:
+        if threshold is not None:
+            x = x.head(threshold)
         x.columns = x.columns.map(str)
-        response = {"schema": pd.io.json.build_table_schema(x),"data": x.to_dict(orient="records")}
-        return json.dumps(response,default=_jupyterlab_variableinspector_default)
+        response = {"schema": pd.io.json.build_table_schema(x), "data": x.to_dict(orient="records")}
+        return json.dumps(response, default=_jupyterlab_variableinspector_default)
     elif np and pd and type(x).__name__ in ["ndarray"]:
         df = pd.DataFrame(x)
+        if threshold is not None:
+            df = df.head(threshold)
         df.columns = df.columns.map(str)
         response = {"schema": pd.io.json.build_table_schema(df), "data": df.to_dict(orient="records")}
         return json.dumps(response,default=_jupyterlab_variableinspector_default)
+    elif tf and isinstance(x, tf.Variable):
+        df = K.get_value(x)
+        return _jupyterlab_variableinspector_getmatrixcontent(df)
 
 def _jupyterlab_variableinspector_default(o):
     if isinstance(o, np.number): return int(o)  


### PR DESCRIPTION
This adds Tensorflow/Keras support and Spark support

![image](https://user-images.githubusercontent.com/2498638/42480133-3cefc83c-841f-11e8-9313-e40402485854.png)

Now by default we shall take in the first `<_jupyterlab_variableinspector_maxrows>` instead of everything

```
_jupyterlab_variableinspector_maxrows = 10**6 # None for view all
```

Setting it to `10**6` might be too high based on me testing it - but its a strawman we can work with initially.


Address #18 