### PR TITLE
Adds simple title to variable inspector

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -160,7 +160,6 @@ export
 
         let reply: Promise<KernelMessage.IExecuteReplyMsg> = this._connector.fetch( request, ( () => { } ) );
         return reply;
-
     }
     
     /*
@@ -225,4 +224,51 @@ namespace VariableInspectionHandler {
         matrixQueryCommand: string;
         initScript: string;
     }
+}
+
+export
+    class DummyHandler implements IDisposable, IVariableInspector.IInspectable{
+        private _isDisposed = false;
+        private _disposed = new Signal<this,void>( this );
+        private _inspected = new Signal<this, IVariableInspector.IVariableInspectorUpdate>( this );
+        private _connector : KernelConnector;
+        
+        constructor(connector : KernelConnector) {
+            this._connector = connector;
+        }
+                
+        get disposed() : ISignal<DummyHandler, void>{
+            return this._disposed;
+        }
+       
+        get isDisposed() : boolean {
+            return this._isDisposed;
+        }
+       
+        get inspected() : ISignal<DummyHandler, IVariableInspector.IVariableInspectorUpdate>{
+            return this._inspected;
+        }
+       
+        dispose(): void {
+            if ( this.isDisposed ) {
+                return;
+            }
+            this._isDisposed = true;
+            this._disposed.emit( void 0 );
+            Signal.clearData( this );
+        }
+       
+        public performInspection(): void{
+            let title: IVariableInspector.IVariableTitle;
+            title = {
+                contextName: this._connector.context || "",
+                kernelName : this._connector.kernelname || "",
+                languageName : this._connector.kerneltype || ""
+            };
+            this._inspected.emit( <IVariableInspector.IVariableInspectorUpdate>{title : title, payload : []});
+        }
+        
+        public performMatrixInspection(varName : string, maxRows : number): Promise<DataModel>{
+            return new Promise(function(resolve, reject) { reject("Cannot inspect matrices w/ the DummyHandler!") });
+        }
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -261,7 +261,7 @@ export
         public performInspection(): void{
             let title: IVariableInspector.IVariableTitle;
             title = {
-                contextName: this._connector.context || "",
+                contextName: " <b>Unsupported language</b> ",
                 kernelName : this._connector.kernelname || "",
                 languageName : this._connector.kerneltype || ""
             };

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -177,10 +177,15 @@ export
                 let content: string = <string>payload.data["text/plain"];
                 content = content.replace( /^'|'$/g, '' ).replace( /\\"/g, "\"" ).replace( /\\'/g, "\'" );
 
-                let update: IVariableInspector.IVariableInspectorUpdate;
-                update = <IVariableInspector.IVariableInspectorUpdate>JSON.parse( content );
+                let update: IVariableInspector.IVariable[];
+                update = <IVariableInspector.IVariable[]>JSON.parse( content );
 
-                this._inspected.emit( update );
+                let title: IVariableInspector.IVariableTitle;
+                title.contextName = this._connector.context;
+                title.kernelName = this._connector.kerneltype;
+                title.languageName = this._connector.kerneltype;
+
+                this._inspected.emit( [title, update] );
                 break;
             default:
                 break;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -181,9 +181,11 @@ export
                 update = <IVariableInspector.IVariable[]>JSON.parse( content );
 
                 let title: IVariableInspector.IVariableTitle;
-                title.contextName = this._connector.context;
-                title.kernelName = this._connector.kerneltype;
-                title.languageName = this._connector.kerneltype;
+                title = {
+                    contextName: this._connector.context || "",
+                    kernelName : this._connector.kernelname || "",
+                    languageName : this._connector.kerneltype || ""
+                };
 
                 this._inspected.emit( [title, update] );
                 break;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -162,9 +162,7 @@ export
         return reply;
 
     }
-
-
-
+    
     /*
      * Handle query response. Emit new signal containing the IVariableInspector.IInspectorUpdate object.
      * (TODO: query resp. could be forwarded to panel directly)
@@ -187,16 +185,12 @@ export
                     languageName : this._connector.kerneltype || ""
                 };
 
-                this._inspected.emit( [title, update] );
+                this._inspected.emit( {title: title, payload: update} );
                 break;
             default:
                 break;
         }
     };
-
-
-
-
 
     /*
      * Invokes a inspection if the signal emitted from specified session is an 'execute_input' msg.
@@ -214,8 +208,6 @@ export
                 break;
         }
     };
-
-
 }
 
 /**
@@ -234,6 +226,3 @@ namespace VariableInspectionHandler {
         initScript: string;
     }
 }
-
-
-

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -179,7 +179,7 @@ export
 
                 let title: IVariableInspector.IVariableTitle;
                 title = {
-                    contextName: this._connector.context || "",
+                    contextName: "",
                     kernelName : this._connector.kernelname || "",
                     languageName : this._connector.kerneltype || ""
                 };
@@ -261,7 +261,7 @@ export
         public performInspection(): void{
             let title: IVariableInspector.IVariableTitle;
             title = {
-                contextName: " <b>Unsupported language</b> ",
+                contextName: ". <b>Language currently not supported.</b> ",
                 kernelName : this._connector.kernelname || "",
                 languageName : this._connector.kerneltype || ""
             };

--- a/src/kernelconnector.ts
+++ b/src/kernelconnector.ts
@@ -29,8 +29,17 @@ export
     }
 
 
+
     get kerneltype(): string {
         return this._session.kernel.info.language_info.name;
+    }
+
+    get context(): string {
+        return this._session.kernel.name
+    }
+
+    get kernelname(): string {
+        return this._session.kernel.name;
     }
 
 

--- a/src/kernelconnector.ts
+++ b/src/kernelconnector.ts
@@ -35,7 +35,9 @@ export
     }
 
     get context(): string {
-        return this._session.kernel.name
+        // dummy status - for say sending message if language not implemented
+        // or other debugging?
+        return "status - ok";
     }
 
     get kernelname(): string {

--- a/src/variableinspector.ts
+++ b/src/variableinspector.ts
@@ -16,7 +16,7 @@ import {
 
 import '../style/index.css';
 
-
+const TITLE_CLASS = "jp-VarInspector-title";
 const PANEL_CLASS = "jp-VarInspector";
 const TABLE_CLASS = "jp-VarInspector-table";
 
@@ -50,8 +50,7 @@ namespace IVariableInspector {
     }
 
     export
-        type IVariableInspectorUpdate = Array<IVariable>;
-
+        type IVariableInspectorUpdate = [IVariableTitle, Array<IVariable>];
 
     export
         interface IVariable {
@@ -62,6 +61,12 @@ namespace IVariableInspector {
         varType: string;
         isMatrix: Boolean;
     }
+    export
+        interface IVariableTitle {
+        kernelName: string;
+        languageName: string;
+        contextName: string;
+        }
 }
 
 
@@ -73,13 +78,17 @@ export
 
     private _source: IVariableInspector.IInspectable | null = null;
     private _table: HTMLTableElement;
+    private _title: HTMLElement;
 
 
     constructor() {
         super();
         this.addClass( PANEL_CLASS );
+        this._title = Private.createTitle();
+        this._title.className = TITLE_CLASS;
         this._table = Private.createTable();
         this._table.className = TABLE_CLASS;
+        this.node.appendChild( this._title as HTMLElement );
         this.node.appendChild( this._table as HTMLElement );
     }
 
@@ -118,13 +127,18 @@ export
         super.dispose();
     }
 
-    protected onInspectorUpdate( sender: any, args: IVariableInspector.IVariableInspectorUpdate ): void {
+    protected onInspectorUpdate( sender: any, allArgs: IVariableInspector.IVariableInspectorUpdate): void {
 
+        let title = allArgs[0];
+        let args = allArgs[1];
+
+        this._title.innerHTML = "kernel:"+title.kernelName+",language:"+title.languageName+",context:"+title.contextName;
 
         //Render new variable state
         let row: HTMLTableRowElement;
         this._table.deleteTFoot();
         this._table.createTFoot();
+
         for ( var index = 0; index < args.length; index++ ) {
             row = this._table.tFoot.insertRow();
             if ( args[index].isMatrix ) {
@@ -195,5 +209,12 @@ namespace Private {
         let cell5 = hrow.insertCell( 4 );
         cell5.innerHTML = "Content";
         return table;
+    }
+
+    export
+        function createTitle(header="") {
+        let title = document.createElement( "p" );
+        title.innerHTML = header;
+        return title;
     }
 }

--- a/src/variableinspector.ts
+++ b/src/variableinspector.ts
@@ -63,9 +63,9 @@ namespace IVariableInspector {
     }
     export
         interface IVariableTitle {
-        kernelName: string;
-        languageName: string;
-        contextName: string;
+        kernelName?: string;
+        languageName?: string;
+        contextName?: string;
         }
 }
 
@@ -132,7 +132,7 @@ export
         let title = allArgs[0];
         let args = allArgs[1];
 
-        this._title.innerHTML = "kernel:"+title.kernelName+",language:"+title.languageName+",context:"+title.contextName;
+        this._title.innerHTML = "kernel:"+title.kernelName+", language:"+title.languageName+", context:"+title.contextName;
 
         //Render new variable state
         let row: HTMLTableRowElement;

--- a/src/variableinspector.ts
+++ b/src/variableinspector.ts
@@ -46,13 +46,13 @@ namespace IVariableInspector {
         disposed: ISignal<any, void>;
         inspected: ISignal<any, IVariableInspectorUpdate>;
         performInspection(): void;
-        performMatrixInspection( varName: string ): Promise<DataModel>;
+        performMatrixInspection( varName: string, maxRows? : number ): Promise<DataModel>;
     }
 
     export
         interface IVariableInspectorUpdate {
-            title: IVariableTitle;
-            payload: Array<IVariable>;
+        title: IVariableTitle;
+        payload: Array<IVariable>;
     } 
 
     export
@@ -62,7 +62,7 @@ namespace IVariableInspector {
         varShape: string;
         varContent: string;
         varType: string;
-        isMatrix: Boolean;
+        isMatrix: boolean;
     }
     export
         interface IVariableTitle {

--- a/src/variableinspector.ts
+++ b/src/variableinspector.ts
@@ -19,6 +19,7 @@ import '../style/index.css';
 const TITLE_CLASS = "jp-VarInspector-title";
 const PANEL_CLASS = "jp-VarInspector";
 const TABLE_CLASS = "jp-VarInspector-table";
+const TABLE_BODY_CLASS = "jp-VarInspector-content";
 
 /**
  * The inspector panel token.
@@ -141,7 +142,7 @@ export
         let row: HTMLTableRowElement;
         this._table.deleteTFoot();
         this._table.createTFoot();
-
+        this._table.tFoot.className = TABLE_BODY_CLASS;
         for ( var index = 0; index < args.length; index++ ) {
             row = this._table.tFoot.insertRow();
             if ( args[index].isMatrix ) {

--- a/src/variableinspector.ts
+++ b/src/variableinspector.ts
@@ -69,7 +69,7 @@ namespace IVariableInspector {
         interface IVariableTitle {
         kernelName?: string;
         languageName?: string;
-        contextName?: string;
+        contextName?: string; //Context currently reserved for special information.
         }
 }
 
@@ -136,7 +136,7 @@ export
         let title = allArgs.title;
         let args = allArgs.payload;
 
-        this._title.innerHTML = "kernel:"+title.kernelName+", language:"+title.languageName+", context:"+title.contextName;
+        this._title.innerHTML = "    Inspecting " + title.languageName + "-kernel '"+title.kernelName + "' "+title.contextName;
 
         //Render new variable state
         let row: HTMLTableRowElement;

--- a/src/variableinspector.ts
+++ b/src/variableinspector.ts
@@ -50,7 +50,10 @@ namespace IVariableInspector {
     }
 
     export
-        type IVariableInspectorUpdate = [IVariableTitle, Array<IVariable>];
+        interface IVariableInspectorUpdate {
+            title: IVariableTitle;
+            payload: Array<IVariable>;
+    } 
 
     export
         interface IVariable {
@@ -129,8 +132,8 @@ export
 
     protected onInspectorUpdate( sender: any, allArgs: IVariableInspector.IVariableInspectorUpdate): void {
 
-        let title = allArgs[0];
-        let args = allArgs[1];
+        let title = allArgs.title;
+        let args = allArgs.payload;
 
         this._title.innerHTML = "kernel:"+title.kernelName+", language:"+title.languageName+", context:"+title.contextName;
 

--- a/style/index.css
+++ b/style/index.css
@@ -20,15 +20,20 @@
     background-color: #f9f9f9;
 }
 
-.jp-VarInspector-table tr:hover {background-color: #ddd;}
+.jp-VarInspector-content tr:hover {background-color: #ddd;}
+
 
 .jp-VarInspector-table thead{
 	font-size: var(--jp-ui-font-size1);
-    font-weight: bold;
     text-align: center;
     height: 50px;
     background-color: #f37726;
     color: white;
+}
+
+.jp-VarInspector-title {
+	font-size: var(--jp-ui-font-size1);
+	text-align: center;
 }
 
 

--- a/style/index.css
+++ b/style/index.css
@@ -26,14 +26,15 @@
 .jp-VarInspector-table thead{
 	font-size: var(--jp-ui-font-size1);
     text-align: center;
-    height: 50px;
-    background-color: #f37726;
+    background-color: #f37626;
     color: white;
+	font-weight: 600;
 }
 
 .jp-VarInspector-title {
 	font-size: var(--jp-ui-font-size1);
-	text-align: center;
+	text-align: left;
+	padding-left: 10px;
 }
 
 


### PR DESCRIPTION
First cut on #26. Figured I'll send this through and get some agreement before trying to solve everything in the world - happy if you decide **NOT** to merge until it looks "pretty" enough

To do list (for future PRs? Even without trying there's a number of items I think should be discussed first)

- [ ] Fix up CSS - I think better to do it all at once with the colour scheme; leave that for you to decide
- [ ] Agree on how to raise status when language not supported and add it to the functionality (see #25)
- [ ] notebook titles, intentionally skipped on that at the moment.

Screenshot below shows that it works and reflects the kernel names

Random comment:

- See that the language name is always Python even when switching between python 2 and python 3; perhaps we can remove the `python2`, `python3` options in `inspectorscripts.ts`

![title](https://user-images.githubusercontent.com/2498638/42537777-37b43e42-84d9-11e8-9c18-20ce6900f68e.gif)

