### PR TITLE
Fix console spam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 npm-debug.log
 package-lock.json
 .project
+.settings
+.ipynb

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For the time being, this project is still in its first steps. Contributions in a
 
 ## Prerequisites
 
-* JupyterLab
+* JupyterLab [>= 0.33] 
 
 ## Installation
 In this early stage you can install this extension by building it from source.
@@ -24,7 +24,6 @@ Download the repository and build the project with `npm install` and `npm run bu
 
 
 ## TODOs
-~~- [ ] Load inspection script from relative paths.~~
 - [x] Add a better presentation (datagrids) for dataframes and ndarrays.
 - [ ] Allow sorting the inspector table.
 - [ ] Add support for other languages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,274 +5,736 @@
   "requires": true,
   "dependencies": {
     "@jupyterlab/application": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-0.16.3.tgz",
-      "integrity": "sha512-ULqbBre9hTOzX++0gWZrLIh83JcQ6zktsODxpoJ426SeQDyO5MyEUFAQHRrzkSC536lcfWiH2XoV5CVeGxNMTg==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-0.17.2.tgz",
+      "integrity": "sha512-VnBAdB1aeGxQV5cRtKEzETaLhTDgy5al8FmbX7Gzu/sab5ghIyg5vtPNdS5UqEoPWbRnw9WJlp+A0mRPFqIZaA==",
       "requires": {
-        "@jupyterlab/apputils": "^0.16.4",
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/docregistry": "^0.16.3",
-        "@jupyterlab/rendermime": "^0.16.3",
-        "@jupyterlab/rendermime-interfaces": "^1.0.10",
-        "@jupyterlab/services": "^2.0.3",
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/application": "^1.5.0",
-        "@phosphor/commands": "^1.4.0",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/properties": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.5.0"
+        "@jupyterlab/apputils": "0.17.2",
+        "@jupyterlab/coreutils": "2.0.2",
+        "@jupyterlab/docregistry": "0.17.2",
+        "@jupyterlab/rendermime": "0.17.2",
+        "@jupyterlab/rendermime-interfaces": "1.1.2",
+        "@jupyterlab/services": "3.0.3",
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/application": "1.6.0",
+        "@phosphor/commands": "1.5.0",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/properties": "1.1.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/widgets": "1.6.0"
       }
     },
     "@jupyterlab/apputils": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-0.16.4.tgz",
-      "integrity": "sha512-HC9EbpnuH4YgqtnvqniEbCBaAv8C5DEYaoONAUGNB+r9Z30MzZnJf5zdDpTkng5yYxmOJbILZhwyHeczzY9C6A==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-0.17.2.tgz",
+      "integrity": "sha512-uSSuldHn/p8Lh2J2IhM+aIMqtKXRxBJP1Yppvkmo1CBnyCDVUnvZuzSWJKRjG5fotuYmU+t2KmXM4yENntp7Aw==",
       "requires": {
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/services": "^2.0.3",
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/commands": "^1.4.0",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/domutils": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/properties": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/virtualdom": "^1.1.2",
-        "@phosphor/widgets": "^1.5.0",
-        "@types/react": "~16.0.19",
-        "react": "~16.2.0",
-        "react-dom": "~16.2.0",
-        "sanitize-html": "~1.14.3"
+        "@jupyterlab/coreutils": "2.0.2",
+        "@jupyterlab/services": "3.0.3",
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/commands": "1.5.0",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/domutils": "1.1.2",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/properties": "1.1.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/virtualdom": "1.1.2",
+        "@phosphor/widgets": "1.6.0",
+        "@types/react": "16.0.41",
+        "react": "16.4.1",
+        "react-dom": "16.4.1",
+        "sanitize-html": "1.14.3"
+      },
+      "dependencies": {
+        "@jupyterlab/coreutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-2.0.2.tgz",
+          "integrity": "sha512-Gg+jpF75a4ziaqOEBX7VaQwyCZdiZVUDmPgkxhUfH20MFMEsh6+4Qs9uFUyfrjFUV3iQH9QXUAsdZ7iurqFL0Q==",
+          "requires": {
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/signaling": "1.2.2",
+            "ajv": "5.1.6",
+            "comment-json": "1.1.3",
+            "minimist": "1.2.0",
+            "moment": "2.21.0",
+            "path-posix": "1.0.0",
+            "url-parse": "1.1.9"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.0.2.tgz",
+          "integrity": "sha512-CvTdsEqkwGG81/5bxX74ectNNPoSxuyTMkpPYkbWITKBbhQbPGQQAwAxCTUHm8YBFfUgmWQBHVWNfkZgnuJIsQ==",
+          "requires": {
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/messaging": "1.2.2",
+            "@phosphor/signaling": "1.2.2"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-3.0.3.tgz",
+          "integrity": "sha512-XnMGfWG20xvyXDRV4Iy3xuSBosF7nCYQZQWLX2sUX0X7nwqwKSW6t4AKqa6mL+mLFkRpdgZTmoU76JDpZNUwog==",
+          "requires": {
+            "@jupyterlab/coreutils": "2.0.2",
+            "@jupyterlab/observables": "2.0.2",
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/signaling": "1.2.2",
+            "node-fetch": "1.7.3",
+            "ws": "1.1.5"
+          }
+        },
+        "react": {
+          "version": "16.4.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+          "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+          "requires": {
+            "fbjs": "0.8.17",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          }
+        },
+        "react-dom": {
+          "version": "16.4.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+          "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+          "requires": {
+            "fbjs": "0.8.17",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          }
+        }
+      }
+    },
+    "@jupyterlab/attachments": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/attachments/-/attachments-0.17.1.tgz",
+      "integrity": "sha1-Mr3b6NUC+U0pHnDFkFcAymTsUwI=",
+      "requires": {
+        "@jupyterlab/coreutils": "2.0.1",
+        "@jupyterlab/observables": "2.0.1",
+        "@jupyterlab/rendermime": "0.17.1",
+        "@jupyterlab/rendermime-interfaces": "1.1.1",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/signaling": "1.2.2"
+      },
+      "dependencies": {
+        "@jupyterlab/apputils": {
+          "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-0.17.1.tgz",
+          "integrity": "sha1-XaWC6pVUQ4evtSAmCLfnbbKGwqQ=",
+          "requires": {
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/services": "3.0.2",
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/commands": "1.5.0",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/domutils": "1.1.2",
+            "@phosphor/messaging": "1.2.2",
+            "@phosphor/properties": "1.1.2",
+            "@phosphor/signaling": "1.2.2",
+            "@phosphor/virtualdom": "1.1.2",
+            "@phosphor/widgets": "1.6.0",
+            "@types/react": "16.0.41",
+            "react": "16.4.1",
+            "react-dom": "16.4.1",
+            "sanitize-html": "1.14.3"
+          }
+        },
+        "@jupyterlab/codeeditor": {
+          "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-0.17.1.tgz",
+          "integrity": "sha1-jFmWiMMUVb0AG335I6fGzRLoj8k=",
+          "requires": {
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/observables": "2.0.1",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/messaging": "1.2.2",
+            "@phosphor/signaling": "1.2.2",
+            "@phosphor/widgets": "1.6.0",
+            "react": "16.4.1",
+            "react-dom": "16.4.1"
+          }
+        },
+        "@jupyterlab/codemirror": {
+          "version": "0.17.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-0.17.2.tgz",
+          "integrity": "sha1-UCx1pfoJtWjnQ+OJSxZiycJtJUY=",
+          "requires": {
+            "@jupyterlab/apputils": "0.17.1",
+            "@jupyterlab/codeeditor": "0.17.1",
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/observables": "2.0.1",
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/signaling": "1.2.2",
+            "codemirror": "5.39.2"
+          }
+        },
+        "@jupyterlab/coreutils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-2.0.1.tgz",
+          "integrity": "sha1-TPFbZesLuuO0KmuZ2L0NoxdCmhw=",
+          "requires": {
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/signaling": "1.2.2",
+            "ajv": "5.1.6",
+            "comment-json": "1.1.3",
+            "minimist": "1.2.0",
+            "moment": "2.21.0",
+            "path-posix": "1.0.0",
+            "url-parse": "1.1.9"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.0.1.tgz",
+          "integrity": "sha1-88j0AgaHJxUj4LCclbKpACTiCKQ=",
+          "requires": {
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/messaging": "1.2.2",
+            "@phosphor/signaling": "1.2.2"
+          }
+        },
+        "@jupyterlab/rendermime": {
+          "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-0.17.1.tgz",
+          "integrity": "sha1-uYdy7M/fS3qynuKLF7MzlXHb/7U=",
+          "requires": {
+            "@jupyterlab/apputils": "0.17.1",
+            "@jupyterlab/codemirror": "0.17.2",
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/observables": "2.0.1",
+            "@jupyterlab/rendermime-interfaces": "1.1.1",
+            "@jupyterlab/services": "3.0.2",
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/messaging": "1.2.2",
+            "@phosphor/signaling": "1.2.2",
+            "@phosphor/widgets": "1.6.0",
+            "ansi_up": "3.0.0",
+            "marked": "0.4.0"
+          }
+        },
+        "@jupyterlab/rendermime-interfaces": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.1.1.tgz",
+          "integrity": "sha1-JuFDYuRIVLwbhgo5hrPKa8lRjhM=",
+          "requires": {
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/widgets": "1.6.0"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-3.0.2.tgz",
+          "integrity": "sha1-p7octVoVVAIu1O+awZHk+kfyr6Q=",
+          "requires": {
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/observables": "2.0.1",
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/signaling": "1.2.2",
+            "node-fetch": "1.7.3",
+            "ws": "1.1.5"
+          }
+        },
+        "codemirror": {
+          "version": "5.39.2",
+          "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.39.2.tgz",
+          "integrity": "sha512-mchBy0kQ1Wggi+e58SmoLgKO4nG7s/BqNg6/6TRbhsnXI/KRG+fKAvRQ1LLhZZ6ZtUoDQ0dl5aMhE+IkSRh60Q=="
+        },
+        "marked": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+          "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
+        },
+        "react": {
+          "version": "16.4.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+          "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+          "requires": {
+            "fbjs": "0.8.17",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          }
+        },
+        "react-dom": {
+          "version": "16.4.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+          "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+          "requires": {
+            "fbjs": "0.8.17",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          }
+        }
       }
     },
     "@jupyterlab/cells": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/cells/-/cells-0.16.3.tgz",
-      "integrity": "sha512-OYfcE+swrZoGcpW5JeIibrY/oYvaPMTllYxtIWWpLeB9x2ufP1ZottuMDsHDLQYHK+7pwik+J5+KgzKowklHiQ==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/cells/-/cells-0.17.2.tgz",
+      "integrity": "sha512-aGsfyeEqc0qB5az6n+fMYIYQPznFUZBNXbq3HFUXsrkxxyQ6WZLePp3gvjKgbiAefxWyDuwKQhWkWgetPOFxjw==",
       "requires": {
-        "@jupyterlab/apputils": "^0.16.4",
-        "@jupyterlab/codeeditor": "^0.16.2",
-        "@jupyterlab/codemirror": "^0.16.3",
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/observables": "^1.0.10",
-        "@jupyterlab/outputarea": "^0.16.3",
-        "@jupyterlab/rendermime": "^0.16.3",
-        "@jupyterlab/services": "^2.0.3",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.5.0",
-        "react": "~16.2.0"
+        "@jupyterlab/apputils": "0.17.2",
+        "@jupyterlab/attachments": "0.17.2",
+        "@jupyterlab/codeeditor": "0.17.2",
+        "@jupyterlab/codemirror": "0.17.3",
+        "@jupyterlab/coreutils": "2.0.2",
+        "@jupyterlab/observables": "2.0.2",
+        "@jupyterlab/outputarea": "0.17.2",
+        "@jupyterlab/rendermime": "0.17.2",
+        "@jupyterlab/services": "3.0.3",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/widgets": "1.6.0",
+        "react": "16.4.1"
+      },
+      "dependencies": {
+        "@jupyterlab/attachments": {
+          "version": "0.17.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/attachments/-/attachments-0.17.2.tgz",
+          "integrity": "sha512-M59BfZ5N/9hGKySHX4T5qhZAbuWNWNPvwT2e/kcWxUzqM6SZz2MBlr9TvuY1pR7iPCQBEu54hzKWe0qOePZfzQ==",
+          "requires": {
+            "@jupyterlab/coreutils": "2.0.2",
+            "@jupyterlab/observables": "2.0.2",
+            "@jupyterlab/rendermime": "0.17.2",
+            "@jupyterlab/rendermime-interfaces": "1.1.2",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/signaling": "1.2.2"
+          }
+        }
       }
     },
     "@jupyterlab/codeeditor": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-0.16.2.tgz",
-      "integrity": "sha512-KGYQUC2okIdY9a/4M6EGH/wZpM/cvrvybcI+O/Y7G0MbDVVn9xHt9RLMlk7pHvJgIfjL8Bp4boux2iY2xqLJ2Q==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-0.17.2.tgz",
+      "integrity": "sha512-gWHOA/9+oVEPc/o704IQyyuSrnDLs/S9MtNIYFTn8fyXUaIpRDfLAL2UFE7JCKbm1OwhOoCOs/NktZlQUXpUgg==",
       "requires": {
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/observables": "^1.0.10",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.5.0",
-        "react": "~16.2.0",
-        "react-dom": "~16.2.0"
+        "@jupyterlab/coreutils": "2.0.2",
+        "@jupyterlab/observables": "2.0.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/widgets": "1.6.0",
+        "react": "16.4.1",
+        "react-dom": "16.4.1"
       }
     },
     "@jupyterlab/codemirror": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-0.16.3.tgz",
-      "integrity": "sha512-06ftGNma/FehRjR9eGc/k/Yp8ktPIAoiR3f6eyErcPQ/5SXySCbZIgn+A1wu9KjwvUP0Jn83xOcACSvZ3y9MvA==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-0.17.3.tgz",
+      "integrity": "sha512-jmFJuzxWvgkLV2mr1CnB+D+jYOErGeY4w2NzndRDWul/+wSpTOO0P2jXwEEFnKwYgWkqmCjq3Z5YS+nRqsAvHA==",
       "requires": {
-        "@jupyterlab/apputils": "^0.16.4",
-        "@jupyterlab/codeeditor": "^0.16.2",
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/observables": "^1.0.10",
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2",
-        "codemirror": "~5.35.0"
+        "@jupyterlab/apputils": "0.17.2",
+        "@jupyterlab/codeeditor": "0.17.2",
+        "@jupyterlab/coreutils": "2.0.2",
+        "@jupyterlab/observables": "2.0.2",
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/signaling": "1.2.2",
+        "codemirror": "5.39.2"
       }
     },
     "@jupyterlab/console": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/console/-/console-0.16.3.tgz",
-      "integrity": "sha512-OiD59OXQuTRjRbhTAcXH9E2ATeh334+CWwIrfN8lywDcr6WixJIiEYK4TlJLNmzvDqAGo22OF9sIlIFusNlPOg==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/console/-/console-0.17.1.tgz",
+      "integrity": "sha1-LffSErlBTdK7Fs56kuSs6kxp3LI=",
       "requires": {
-        "@jupyterlab/apputils": "^0.16.4",
-        "@jupyterlab/cells": "^0.16.3",
-        "@jupyterlab/codeeditor": "^0.16.2",
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/observables": "^1.0.10",
-        "@jupyterlab/rendermime": "^0.16.3",
-        "@jupyterlab/services": "^2.0.3",
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.5.0"
+        "@jupyterlab/apputils": "0.17.1",
+        "@jupyterlab/cells": "0.17.1",
+        "@jupyterlab/codeeditor": "0.17.1",
+        "@jupyterlab/coreutils": "2.0.1",
+        "@jupyterlab/observables": "2.0.1",
+        "@jupyterlab/rendermime": "0.17.1",
+        "@jupyterlab/services": "3.0.2",
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/widgets": "1.6.0"
+      },
+      "dependencies": {
+        "@jupyterlab/apputils": {
+          "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-0.17.1.tgz",
+          "integrity": "sha1-XaWC6pVUQ4evtSAmCLfnbbKGwqQ=",
+          "requires": {
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/services": "3.0.2",
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/commands": "1.5.0",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/domutils": "1.1.2",
+            "@phosphor/messaging": "1.2.2",
+            "@phosphor/properties": "1.1.2",
+            "@phosphor/signaling": "1.2.2",
+            "@phosphor/virtualdom": "1.1.2",
+            "@phosphor/widgets": "1.6.0",
+            "@types/react": "16.0.41",
+            "react": "16.4.1",
+            "react-dom": "16.4.1",
+            "sanitize-html": "1.14.3"
+          }
+        },
+        "@jupyterlab/cells": {
+          "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/cells/-/cells-0.17.1.tgz",
+          "integrity": "sha1-br0rKUmyJtnRZ+izYAMsI0VmiJE=",
+          "requires": {
+            "@jupyterlab/apputils": "0.17.1",
+            "@jupyterlab/attachments": "0.17.1",
+            "@jupyterlab/codeeditor": "0.17.1",
+            "@jupyterlab/codemirror": "0.17.2",
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/observables": "2.0.1",
+            "@jupyterlab/outputarea": "0.17.1",
+            "@jupyterlab/rendermime": "0.17.1",
+            "@jupyterlab/services": "3.0.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/messaging": "1.2.2",
+            "@phosphor/signaling": "1.2.2",
+            "@phosphor/widgets": "1.6.0",
+            "react": "16.4.1"
+          }
+        },
+        "@jupyterlab/codeeditor": {
+          "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-0.17.1.tgz",
+          "integrity": "sha1-jFmWiMMUVb0AG335I6fGzRLoj8k=",
+          "requires": {
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/observables": "2.0.1",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/messaging": "1.2.2",
+            "@phosphor/signaling": "1.2.2",
+            "@phosphor/widgets": "1.6.0",
+            "react": "16.4.1",
+            "react-dom": "16.4.1"
+          }
+        },
+        "@jupyterlab/codemirror": {
+          "version": "0.17.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-0.17.2.tgz",
+          "integrity": "sha1-UCx1pfoJtWjnQ+OJSxZiycJtJUY=",
+          "requires": {
+            "@jupyterlab/apputils": "0.17.1",
+            "@jupyterlab/codeeditor": "0.17.1",
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/observables": "2.0.1",
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/signaling": "1.2.2",
+            "codemirror": "5.39.2"
+          }
+        },
+        "@jupyterlab/coreutils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-2.0.1.tgz",
+          "integrity": "sha1-TPFbZesLuuO0KmuZ2L0NoxdCmhw=",
+          "requires": {
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/signaling": "1.2.2",
+            "ajv": "5.1.6",
+            "comment-json": "1.1.3",
+            "minimist": "1.2.0",
+            "moment": "2.21.0",
+            "path-posix": "1.0.0",
+            "url-parse": "1.1.9"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.0.1.tgz",
+          "integrity": "sha1-88j0AgaHJxUj4LCclbKpACTiCKQ=",
+          "requires": {
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/messaging": "1.2.2",
+            "@phosphor/signaling": "1.2.2"
+          }
+        },
+        "@jupyterlab/outputarea": {
+          "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/outputarea/-/outputarea-0.17.1.tgz",
+          "integrity": "sha1-SvedXopsqCBSz6Oi9Z2uOQejJdQ=",
+          "requires": {
+            "@jupyterlab/apputils": "0.17.1",
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/observables": "2.0.1",
+            "@jupyterlab/rendermime": "0.17.1",
+            "@jupyterlab/rendermime-interfaces": "1.1.1",
+            "@jupyterlab/services": "3.0.2",
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/messaging": "1.2.2",
+            "@phosphor/signaling": "1.2.2",
+            "@phosphor/widgets": "1.6.0"
+          }
+        },
+        "@jupyterlab/rendermime": {
+          "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-0.17.1.tgz",
+          "integrity": "sha1-uYdy7M/fS3qynuKLF7MzlXHb/7U=",
+          "requires": {
+            "@jupyterlab/apputils": "0.17.1",
+            "@jupyterlab/codemirror": "0.17.2",
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/observables": "2.0.1",
+            "@jupyterlab/rendermime-interfaces": "1.1.1",
+            "@jupyterlab/services": "3.0.2",
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/messaging": "1.2.2",
+            "@phosphor/signaling": "1.2.2",
+            "@phosphor/widgets": "1.6.0",
+            "ansi_up": "3.0.0",
+            "marked": "0.4.0"
+          }
+        },
+        "@jupyterlab/rendermime-interfaces": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.1.1.tgz",
+          "integrity": "sha1-JuFDYuRIVLwbhgo5hrPKa8lRjhM=",
+          "requires": {
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/widgets": "1.6.0"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-3.0.2.tgz",
+          "integrity": "sha1-p7octVoVVAIu1O+awZHk+kfyr6Q=",
+          "requires": {
+            "@jupyterlab/coreutils": "2.0.1",
+            "@jupyterlab/observables": "2.0.1",
+            "@phosphor/algorithm": "1.1.2",
+            "@phosphor/coreutils": "1.3.0",
+            "@phosphor/disposable": "1.1.2",
+            "@phosphor/signaling": "1.2.2",
+            "node-fetch": "1.7.3",
+            "ws": "1.1.5"
+          }
+        },
+        "codemirror": {
+          "version": "5.39.2",
+          "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.39.2.tgz",
+          "integrity": "sha512-mchBy0kQ1Wggi+e58SmoLgKO4nG7s/BqNg6/6TRbhsnXI/KRG+fKAvRQ1LLhZZ6ZtUoDQ0dl5aMhE+IkSRh60Q=="
+        },
+        "marked": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+          "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
+        },
+        "react": {
+          "version": "16.4.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+          "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+          "requires": {
+            "fbjs": "0.8.17",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          }
+        },
+        "react-dom": {
+          "version": "16.4.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+          "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+          "requires": {
+            "fbjs": "0.8.17",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          }
+        }
       }
     },
     "@jupyterlab/coreutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-1.1.3.tgz",
-      "integrity": "sha512-H6NgjZKHlDelN1tRsQn6mfO8lC04gcNe3e0ZWD9BTtI7/H4G+8oeEify1NJ9DkS6vl1fo5opsrtxwESnfZXqyw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-2.0.2.tgz",
+      "integrity": "sha512-Gg+jpF75a4ziaqOEBX7VaQwyCZdiZVUDmPgkxhUfH20MFMEsh6+4Qs9uFUyfrjFUV3iQH9QXUAsdZ7iurqFL0Q==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2",
-        "ajv": "~5.1.6",
-        "comment-json": "^1.1.3",
-        "minimist": "~1.2.0",
-        "moment": "~2.21.0",
-        "path-posix": "~1.0.0",
-        "url-parse": "~1.1.9"
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/signaling": "1.2.2",
+        "ajv": "5.1.6",
+        "comment-json": "1.1.3",
+        "minimist": "1.2.0",
+        "moment": "2.21.0",
+        "path-posix": "1.0.0",
+        "url-parse": "1.1.9"
       }
     },
     "@jupyterlab/csvviewer": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/csvviewer/-/csvviewer-0.16.3.tgz",
-      "integrity": "sha512-pgdXkh2oqV6r7+Me+HroUEmpeQkPbRfDMVeCuH8Lz8HazdUgAnB0omcE0SgR7oQ7eX3X2SKzHZSzdQ3qYwtqcg==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/csvviewer/-/csvviewer-0.17.2.tgz",
+      "integrity": "sha512-2jWUgTw5eaBb9Y1Li9TZHwuZTQBL333meXWqGugD66GAiDIUW3xYqKrfk43wYYRYWzlKbyqc7Dgksvqr8NXcJg==",
       "requires": {
-        "@jupyterlab/apputils": "^0.16.4",
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/docregistry": "^0.16.3",
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/datagrid": "^0.1.5",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.5.0"
+        "@jupyterlab/apputils": "0.17.2",
+        "@jupyterlab/coreutils": "2.0.2",
+        "@jupyterlab/docregistry": "0.17.2",
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/datagrid": "0.1.6",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/widgets": "1.6.0"
       }
     },
     "@jupyterlab/docregistry": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-0.16.3.tgz",
-      "integrity": "sha512-c51ebeu5ZQLlJEEwZDGp+iqYY5C7Pbdxc1Mz/0GLIf5jhJZ7RgVEE+dIGsx+qEkt/97iXzdKYdElnxjUPaq/5A==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-0.17.2.tgz",
+      "integrity": "sha512-UjxPo1+UBSRRkKUq57opeQwbVpN/I4vLPnG5Yzcipm7X0i/qpbxDbuluH7BwM3nOrY300Ko8Mhh37if7gABjaQ==",
       "requires": {
-        "@jupyterlab/apputils": "^0.16.4",
-        "@jupyterlab/codeeditor": "^0.16.2",
-        "@jupyterlab/codemirror": "^0.16.3",
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/observables": "^1.0.10",
-        "@jupyterlab/rendermime": "^0.16.3",
-        "@jupyterlab/rendermime-interfaces": "^1.0.10",
-        "@jupyterlab/services": "^2.0.3",
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.5.0"
+        "@jupyterlab/apputils": "0.17.2",
+        "@jupyterlab/codeeditor": "0.17.2",
+        "@jupyterlab/codemirror": "0.17.3",
+        "@jupyterlab/coreutils": "2.0.2",
+        "@jupyterlab/observables": "2.0.2",
+        "@jupyterlab/rendermime": "0.17.2",
+        "@jupyterlab/rendermime-interfaces": "1.1.2",
+        "@jupyterlab/services": "3.0.3",
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/widgets": "1.6.0"
       }
     },
     "@jupyterlab/notebook": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/notebook/-/notebook-0.16.3.tgz",
-      "integrity": "sha512-NC7QuUkeWP5FP92+z0vDoiH6muqfOcY8UIN5FDC74hfbCyL+3AYIOz24Opo46Cdi2rkOOEoKZSa5yrvF2dJ5pQ==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/notebook/-/notebook-0.17.2.tgz",
+      "integrity": "sha512-pITUbp1gFVIeAsADocT0w32Ol2emN76wHyv91CRZPIxPRTz73q7Acbub2BAPfdZKUcCIRLtyF1Fs56c+VEa90w==",
       "requires": {
-        "@jupyterlab/apputils": "^0.16.4",
-        "@jupyterlab/cells": "^0.16.3",
-        "@jupyterlab/codeeditor": "^0.16.2",
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/docregistry": "^0.16.3",
-        "@jupyterlab/observables": "^1.0.10",
-        "@jupyterlab/rendermime": "^0.16.3",
-        "@jupyterlab/services": "^2.0.3",
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/domutils": "^1.1.2",
-        "@phosphor/dragdrop": "^1.3.0",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/properties": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/virtualdom": "^1.1.2",
-        "@phosphor/widgets": "^1.5.0",
-        "react": "~16.2.0"
+        "@jupyterlab/apputils": "0.17.2",
+        "@jupyterlab/cells": "0.17.2",
+        "@jupyterlab/codeeditor": "0.17.2",
+        "@jupyterlab/coreutils": "2.0.2",
+        "@jupyterlab/docregistry": "0.17.2",
+        "@jupyterlab/observables": "2.0.2",
+        "@jupyterlab/rendermime": "0.17.2",
+        "@jupyterlab/services": "3.0.3",
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/domutils": "1.1.2",
+        "@phosphor/dragdrop": "1.3.0",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/properties": "1.1.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/virtualdom": "1.1.2",
+        "@phosphor/widgets": "1.6.0",
+        "react": "16.4.1"
       }
     },
     "@jupyterlab/observables": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-1.0.10.tgz",
-      "integrity": "sha512-HsWchDHXarPHwF/msP7DyLJmfTsmPc+1lL1sLgYzMvU1ARXKalzA3P5LLEyrgrCssemv+pO2IkUviJ0XQKg8eQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.0.2.tgz",
+      "integrity": "sha512-CvTdsEqkwGG81/5bxX74ectNNPoSxuyTMkpPYkbWITKBbhQbPGQQAwAxCTUHm8YBFfUgmWQBHVWNfkZgnuJIsQ==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/signaling": "^1.2.2"
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/signaling": "1.2.2"
       }
     },
     "@jupyterlab/outputarea": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/outputarea/-/outputarea-0.16.3.tgz",
-      "integrity": "sha512-1920Fs7lKJA+aPBAd4gL0aDVaCYFQ/D6Nhrh5V48fC7Q8euBlnf1aeEAADMAkApp21Cy0JkHP9WDkReHF2JHxA==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/outputarea/-/outputarea-0.17.2.tgz",
+      "integrity": "sha512-N6kGyI/qps5btLkrskG9Hl6v5qIsEN8pHh7lJDBd8O+k14/qnsVN0LOetzljREMV1y04YfodBzxi0d4FWG+ftA==",
       "requires": {
-        "@jupyterlab/apputils": "^0.16.4",
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/observables": "^1.0.10",
-        "@jupyterlab/rendermime": "^0.16.3",
-        "@jupyterlab/rendermime-interfaces": "^1.0.10",
-        "@jupyterlab/services": "^2.0.3",
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.5.0"
+        "@jupyterlab/apputils": "0.17.2",
+        "@jupyterlab/coreutils": "2.0.2",
+        "@jupyterlab/observables": "2.0.2",
+        "@jupyterlab/rendermime": "0.17.2",
+        "@jupyterlab/rendermime-interfaces": "1.1.2",
+        "@jupyterlab/services": "3.0.3",
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/widgets": "1.6.0"
       }
     },
     "@jupyterlab/rendermime": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-0.16.3.tgz",
-      "integrity": "sha512-ze1WA6uiTn10YU9yiyX5sUuq6Q5ZMk5FbJx9u0i7WYsgeTybRLl11Y1ebeX63FUlloPh6rIjNpB4a9k0vLGL/w==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-0.17.2.tgz",
+      "integrity": "sha512-QFJpk8/7TQhmhHRX7UU9uYJ+gECfpS5wTJ2racKb+Bl1CQtOYB8wj/QfjHQRL0T5mQB1B3DeslogDPz+H6Kplg==",
       "requires": {
-        "@jupyterlab/apputils": "^0.16.4",
-        "@jupyterlab/codemirror": "^0.16.3",
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/observables": "^1.0.10",
-        "@jupyterlab/rendermime-interfaces": "^1.0.10",
-        "@jupyterlab/services": "^2.0.3",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.5.0",
-        "ansi_up": "^3.0.0",
-        "marked": "~0.3.9"
+        "@jupyterlab/apputils": "0.17.2",
+        "@jupyterlab/codemirror": "0.17.3",
+        "@jupyterlab/coreutils": "2.0.2",
+        "@jupyterlab/observables": "2.0.2",
+        "@jupyterlab/rendermime-interfaces": "1.1.2",
+        "@jupyterlab/services": "3.0.3",
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/widgets": "1.6.0",
+        "ansi_up": "3.0.0",
+        "marked": "0.4.0"
       }
     },
     "@jupyterlab/rendermime-interfaces": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.0.10.tgz",
-      "integrity": "sha512-qApoEHdWmPtyBrvqQras478Nprgyw6Gk7PHT9c5W8lS4eJdNJKsi3zovkeRkUbcFdd2VBgDj/2fzxFMu6DnMUw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.1.2.tgz",
+      "integrity": "sha512-sCsDYuLQbhT79yutGOZ+r32yNE+oKcXWItF1hxH/69rIPQGc9P4bObbY6H4ZhbDm61kSHmqh2ntucmjxjP1kbA==",
       "requires": {
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/widgets": "^1.5.0"
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/widgets": "1.6.0"
       }
     },
     "@jupyterlab/services": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-2.0.3.tgz",
-      "integrity": "sha512-613PALJSc16ce/W5butOnqOTUFspYACB0DQKydIuDVwFefxrdMIBNAk8pqVXih6D2NHQTwC0DZKGViYD8Hj6hg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-3.0.3.tgz",
+      "integrity": "sha512-XnMGfWG20xvyXDRV4Iy3xuSBosF7nCYQZQWLX2sUX0X7nwqwKSW6t4AKqa6mL+mLFkRpdgZTmoU76JDpZNUwog==",
       "requires": {
-        "@jupyterlab/coreutils": "^1.1.3",
-        "@jupyterlab/observables": "^1.0.10",
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2",
-        "node-fetch": "~1.7.3",
-        "ws": "~1.1.4"
+        "@jupyterlab/coreutils": "2.0.2",
+        "@jupyterlab/observables": "2.0.2",
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/signaling": "1.2.2",
+        "node-fetch": "1.7.3",
+        "ws": "1.1.5"
       }
     },
     "@phosphor/algorithm": {
@@ -285,9 +747,9 @@
       "resolved": "https://registry.npmjs.org/@phosphor/application/-/application-1.6.0.tgz",
       "integrity": "sha512-SeW2YFjtpmCYbZPpB4aTehyIsI/iGoSrV60Y4/OAp1CwDRT8eu1Rv276F67aermXQFjLK6c58JGucbhNq/BepQ==",
       "requires": {
-        "@phosphor/commands": "^1.5.0",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/widgets": "^1.6.0"
+        "@phosphor/commands": "1.5.0",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/widgets": "1.6.0"
       }
     },
     "@phosphor/collections": {
@@ -295,7 +757,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.1.2.tgz",
       "integrity": "sha1-xMC4uREpkF+zap8kPy273kYtq40=",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2"
+        "@phosphor/algorithm": "1.1.2"
       }
     },
     "@phosphor/commands": {
@@ -303,12 +765,12 @@
       "resolved": "https://registry.npmjs.org/@phosphor/commands/-/commands-1.5.0.tgz",
       "integrity": "sha512-j8+hIlQZT3imFYVAPO3JxbCUbogOT65uUvUk9AsQXJahm7m8+3a7U4yACshjynJwMM6cxX1AEEo7PUgFwhL97g==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/domutils": "^1.1.2",
-        "@phosphor/keyboard": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2"
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/domutils": "1.1.2",
+        "@phosphor/keyboard": "1.1.2",
+        "@phosphor/signaling": "1.2.2"
       }
     },
     "@phosphor/coreutils": {
@@ -321,14 +783,14 @@
       "resolved": "https://registry.npmjs.org/@phosphor/datagrid/-/datagrid-0.1.6.tgz",
       "integrity": "sha512-JDeM5Y9+S1pvB4u75eYtOeCr6Ra2vLNh4UGNg3aYwtqK8OYNNVBiPhPKK8Fw3zR+vjS3GDy8DYX6A5jRY1uW2g==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/domutils": "^1.1.2",
-        "@phosphor/dragdrop": "^1.3.0",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.6.0"
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/domutils": "1.1.2",
+        "@phosphor/dragdrop": "1.3.0",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/widgets": "1.6.0"
       }
     },
     "@phosphor/disposable": {
@@ -336,7 +798,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.1.2.tgz",
       "integrity": "sha1-oZLdai5sadXQnTns8zTauTd4Bg4=",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2"
+        "@phosphor/algorithm": "1.1.2"
       }
     },
     "@phosphor/domutils": {
@@ -349,8 +811,8 @@
       "resolved": "https://registry.npmjs.org/@phosphor/dragdrop/-/dragdrop-1.3.0.tgz",
       "integrity": "sha1-fOatOdbKIW1ipW94EE0Cp3rmcwc=",
       "requires": {
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2"
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2"
       }
     },
     "@phosphor/keyboard": {
@@ -363,8 +825,8 @@
       "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.2.2.tgz",
       "integrity": "sha1-fYlt3TeXuUo0dwje0T2leD23XBQ=",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/collections": "^1.1.2"
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/collections": "1.1.2"
       }
     },
     "@phosphor/properties": {
@@ -377,7 +839,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.2.2.tgz",
       "integrity": "sha1-P8+Xyojji/s1f+j+a/dRM0elFKk=",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2"
+        "@phosphor/algorithm": "1.1.2"
       }
     },
     "@phosphor/virtualdom": {
@@ -385,7 +847,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor/virtualdom/-/virtualdom-1.1.2.tgz",
       "integrity": "sha1-zlXIbu8x5dDiax3JbqMr1oRFj0E=",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2"
+        "@phosphor/algorithm": "1.1.2"
       }
     },
     "@phosphor/widgets": {
@@ -393,17 +855,17 @@
       "resolved": "https://registry.npmjs.org/@phosphor/widgets/-/widgets-1.6.0.tgz",
       "integrity": "sha512-HqVckVF8rJ15ss0Zf/q0AJ69ZKNFOO26qtNKAdGZ9SmmkSMf73X6pB0R3Fj5+Y4Sjl8ezIIKG6mXj+DxOofnwA==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/commands": "^1.5.0",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/domutils": "^1.1.2",
-        "@phosphor/dragdrop": "^1.3.0",
-        "@phosphor/keyboard": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/properties": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/virtualdom": "^1.1.2"
+        "@phosphor/algorithm": "1.1.2",
+        "@phosphor/commands": "1.5.0",
+        "@phosphor/coreutils": "1.3.0",
+        "@phosphor/disposable": "1.1.2",
+        "@phosphor/domutils": "1.1.2",
+        "@phosphor/dragdrop": "1.3.0",
+        "@phosphor/keyboard": "1.1.2",
+        "@phosphor/messaging": "1.2.2",
+        "@phosphor/properties": "1.1.2",
+        "@phosphor/signaling": "1.2.2",
+        "@phosphor/virtualdom": "1.1.2"
       }
     },
     "@types/react": {
@@ -416,9 +878,9 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.6.tgz",
       "integrity": "sha1-Sy8aGd7Ok9V6whYDfj6XkcfdFWQ=",
       "requires": {
-        "co": "^4.6.0",
-        "json-schema-traverse": "^0.3.0",
-        "json-stable-stringify": "^1.0.1"
+        "co": "4.6.0",
+        "json-schema-traverse": "0.3.1",
+        "json-stable-stringify": "1.0.1"
       }
     },
     "ansi_up": {
@@ -443,7 +905,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -453,16 +915,16 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "codemirror": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.35.0.tgz",
-      "integrity": "sha512-8HQICjZlDfe1ai7bvU6m2uHxuZuFgsUCdDRU9OHVB+2RTRd+FftN1ezVCqbquG0Fyq+wETqyadKhUX46DswSUQ=="
+      "version": "5.39.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.39.2.tgz",
+      "integrity": "sha512-mchBy0kQ1Wggi+e58SmoLgKO4nG7s/BqNg6/6TRbhsnXI/KRG+fKAvRQ1LLhZZ6ZtUoDQ0dl5aMhE+IkSRh60Q=="
     },
     "comment-json": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-1.1.3.tgz",
       "integrity": "sha1-aYbDMw/uDEyeAMI5jNYa+l2PI54=",
       "requires": {
-        "json-parser": "^1.0.0"
+        "json-parser": "1.1.5"
       }
     },
     "concat-map": {
@@ -486,8 +948,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -507,7 +969,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domutils": {
@@ -515,8 +977,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "encoding": {
@@ -524,7 +986,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.23"
       }
     },
     "entities": {
@@ -542,13 +1004,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.18"
       }
     },
     "fs.realpath": {
@@ -563,12 +1025,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "htmlparser2": {
@@ -576,12 +1038,12 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "requires": {
-        "domelementtype": "^1.3.0",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.2",
+        "domutils": "1.7.0",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "iconv-lite": {
@@ -589,7 +1051,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "inflight": {
@@ -598,8 +1060,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -622,8 +1084,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
       }
     },
     "js-tokens": {
@@ -636,7 +1098,7 @@
       "resolved": "https://registry.npmjs.org/json-parser/-/json-parser-1.1.5.tgz",
       "integrity": "sha1-5i7FJh0aal/CDoEqMgdAxtkAVnc=",
       "requires": {
-        "esprima": "^2.7.0"
+        "esprima": "2.7.3"
       }
     },
     "json-schema-traverse": {
@@ -649,7 +1111,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "jsonify": {
@@ -667,13 +1129,13 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -681,7 +1143,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -699,8 +1161,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "object-assign": {
@@ -714,7 +1176,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "options": {
@@ -743,7 +1205,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "prop-types": {
@@ -751,9 +1213,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
       "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       }
     },
     "querystringify": {
@@ -762,25 +1224,25 @@
       "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
     },
     "react": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
-      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.1"
       }
     },
     "react-dom": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.1"
       }
     },
     "readable-stream": {
@@ -788,13 +1250,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "requires-port": {
@@ -808,7 +1270,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "safe-buffer": {
@@ -826,9 +1288,9 @@
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.14.3.tgz",
       "integrity": "sha512-6tjiqhsgfQYNS+5B078RKDij7hSnQtNbWNQVJMjbCYT7XMtBeJLKrqbMT6+o2kva6SqMubcy/CS76/Bs6z49SQ==",
       "requires": {
-        "htmlparser2": "^3.9.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "xtend": "^4.0.0"
+        "htmlparser2": "3.9.2",
+        "lodash.escaperegexp": "4.1.2",
+        "xtend": "4.0.1"
       }
     },
     "setimmediate": {
@@ -841,7 +1303,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "typescript": {
@@ -865,8 +1327,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
       "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
       "requires": {
-        "querystringify": "~1.0.0",
-        "requires-port": "1.0.x"
+        "querystringify": "1.0.0",
+        "requires-port": "1.0.0"
       }
     },
     "util-deprecate": {
@@ -890,8 +1352,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
+        "options": "0.0.6",
+        "ultron": "1.0.2"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/my_name/jupyterlab_myextension",
+  "homepage": "https://github.com/lckr/jupyterlab-variableInspector",
   "bugs": {
-    "url": "https://github.com/my_name/jupyterlab_myextension/issues"
+    "url": "https://github.com/lckr/jupyterlab-variableInspector/issues"
   },
   "license": "BSD-3-Clause",
-  "author": "Lucas Krauss",
+  "author": "lckr",
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
@@ -21,7 +21,7 @@
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/my_name/jupyterlab_myextension.git"
+    "url": "https://github.com/lckr/jupyterlab-variableInspector.git"
   },
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^0.16.0",
-    "@jupyterlab/console": "^0.16.3",
-    "@jupyterlab/csvviewer": "^0.16.3",
-    "@jupyterlab/notebook": "^0.16.3",
-    "@phosphor/datagrid": "^0.1.6"
+    "@jupyterlab/application": "^0.17.0",
+    "@jupyterlab/console": "^0.17.0",
+    "@jupyterlab/csvviewer": "^0.17.0",
+    "@jupyterlab/notebook": "^0.17.0",
+    "@phosphor/datagrid": "^0.1.6",
+    "@jupyterlab/apputils": "^0.17.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.1",

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -44,14 +44,16 @@ export
     private _inspected = new Signal<this, IVariableInspector.IVariableInspectorUpdate>( this );
     private _isDisposed = false;
     private _ready : Promise<void>;
+    private _id : string;
     
 
     constructor( options: VariableInspectionHandler.IOptions ) {
         this._connector = options.connector;
+        this._id = options.id;
         this._queryCommand = options.queryCommand;
         this._matrixQueryCommand = options.matrixQueryCommand;
         this._initScript = options.initScript;
-
+        
         this._ready =  this._connector.ready.then(() => {
             this._initOnKernel().then(( msg:KernelMessage.IExecuteReplyMsg ) => {
             this._connector.iopubMessage.connect( this._queryCall );
@@ -62,6 +64,10 @@ export
         
     }
 
+    get id():string{
+        return this._id;
+    }
+    
     /**
      * A signal emitted when the handler is disposed.
      */
@@ -223,6 +229,7 @@ namespace VariableInspectionHandler {
         queryCommand: string;
         matrixQueryCommand: string;
         initScript: string;
+        id : string;
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from "./handler";
 
 import {
-    VariableInspectorManager
+    VariableInspectorManager, IVariableInspectorManager
 } from "./manager";
 
 import {
@@ -39,251 +39,259 @@ import {
 
 namespace CommandIDs {
     export
-        const open = "variableinspector:open";
+    const open = "variableinspector:open";
 }
 
 /**
  * A service providing variable introspection.
  */
-const variableinspector: JupyterLabPlugin<IVariableInspector> = {
-    id: "jupyterlab-extension:variableinspector",
-    requires: [ICommandPalette, ILayoutRestorer],
-    provides: IVariableInspector,
-    autoStart: true,
-    activate: ( app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRestorer ): IVariableInspector => {
-
-
-        const manager = new VariableInspectorManager();
-        const category = "Variable Inspector";
-        const command = CommandIDs.open;
-        const label = "Open Variable Inspector";
-        const namespace = "variableinspector";
-        const tracker = new InstanceTracker<VariableInspectorPanel>( { namespace } );
-
-
-        /**
-         * Create and track a new inspector.
-         */
-        function newPanel(): VariableInspectorPanel {
-            const panel = new VariableInspectorPanel();
-
-            panel.id = "jp-variableinspector";
-            panel.title.label = "Variable Inspector";
-            panel.title.closable = true;
-            panel.disposed.connect(() => {
-                if ( manager.panel === panel ) {
-                    manager.panel = null;
+const variableinspector: JupyterLabPlugin<IVariableInspectorManager> = {
+        id: "jupyterlab-extension:variableinspector",
+        requires: [ICommandPalette, ILayoutRestorer],
+        provides: IVariableInspectorManager,
+        autoStart: true,
+        activate: ( app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRestorer ): IVariableInspectorManager => {
+            
+            
+            const manager = new VariableInspectorManager();
+            const category = "Variable Inspector";
+            const command = CommandIDs.open;
+            const label = "Open Variable Inspector";
+            const namespace = "variableinspector";
+            const tracker = new InstanceTracker<VariableInspectorPanel>( { namespace } );
+            
+            
+            /**
+             * Create and track a new inspector.
+             */
+            function newPanel(): VariableInspectorPanel {
+                const panel = new VariableInspectorPanel();
+                
+                panel.id = "jp-variableinspector";
+                panel.title.label = "Variable Inspector";
+                panel.title.closable = true;
+                panel.disposed.connect(() => {
+                    if ( manager.panel === panel ) {
+                        manager.panel = null;
+                    }
+                } );
+                
+                //Track the inspector panel
+                tracker.add( panel );
+                
+                return panel;
+            }
+            
+            // Enable state restoration
+            restorer.restore( tracker, {
+                command,
+                args: () => null,
+                name: () => "variableinspector"
+            } );
+            
+            // Add command to palette
+            app.commands.addCommand( command, {
+                label,
+                execute: () => {
+                    if ( !manager.panel || manager.panel.isDisposed ) {
+                        manager.panel = newPanel();
+                    }
+                    if ( !manager.panel.isAttached ) {
+                        app.shell.addToMainArea( manager.panel );
+                    }
+                    if ( manager.source ) {
+                        manager.source.performInspection();
+                    }
+                    app.shell.activateById( manager.panel.id );
                 }
             } );
-
-            //Track the inspector panel
-            tracker.add( panel );
-
-            return panel;
+            palette.addItem( { command, category } );
+            return manager;
         }
-
-        // Enable state restoration
-        restorer.restore( tracker, {
-            command,
-            args: () => null,
-            name: () => "variableinspector"
-        } );
-
-        // Add command to palette
-        app.commands.addCommand( command, {
-            label,
-            execute: () => {
-                if ( !manager.panel || manager.panel.isDisposed ) {
-                    manager.panel = newPanel();
-                }
-                if ( !manager.panel.isAttached ) {
-                    app.shell.addToMainArea( manager.panel );
-                }
-                if ( manager.source ) {
-                    manager.source.performInspection();
-                }
-                app.shell.activateById( manager.panel.id );
-            }
-        } );
-        palette.addItem( { command, category } );
-        return manager;
-    }
 }
 
 /**
  * An extension that registers consoles for variable inspection.
  */
 const consoles: JupyterLabPlugin<void> = {
-    id: "jupyterlab-extension:variableinspector:consoles",
-    requires: [IVariableInspector, IConsoleTracker],
-    autoStart: true,
-    activate: ( app: JupyterLab, manager: IVariableInspector, consoles: IConsoleTracker ): void => {
-        const handlers: { [id: string]: Promise<IVariableInspector.IInspectable> } = {};
-        
-        /**
-         * Subscribes to the creation of new consoles. If a new notebook is created, build a new handler for the consoles.
-         * Adds a promise for a instanced handler to the 'handlers' collection.
-         */
-        consoles.widgetAdded.connect(( sender, consolePanel ) => {
+        id: "jupyterlab-extension:variableinspector:consoles",
+        requires: [IVariableInspectorManager, IConsoleTracker],
+        autoStart: true,
+        activate: ( app: JupyterLab, manager: IVariableInspectorManager, consoles: IConsoleTracker ): void => {
+            const handlers: { [id: string]: Promise<IVariableInspector.IInspectable> } = {};
             
-            handlers[consolePanel.id] = new Promise( function( resolve, reject ) {
-                const session = consolePanel.session;
-                const connector = new KernelConnector( { session } );
-
-                
-                connector.ready.then(() => { // Create connector and init w script if it exists for kernel type.
-                    let kerneltype: string = connector.kerneltype;
-                    let scripts: Promise<Languages.LanguageModel> = Languages.getScript( kerneltype );
-                
-                    scripts.then(( result: Languages.LanguageModel ) => {
-                        let initScript = result.initScript;
-                        let queryCommand = result.queryCommand;
-                        let matrixQueryCommand = result.matrixQueryCommand;
-
-                        const options: VariableInspectionHandler.IOptions = {
-                            queryCommand: queryCommand,
-                            matrixQueryCommand: matrixQueryCommand,
-                            connector: connector,
-                            initScript: initScript
-                        };
-                        const handler = new VariableInspectionHandler( options );
-
-                        consolePanel.disposed.connect(() => {
-                            delete handlers[consolePanel.id];
-                            handler.dispose();
+            /**
+             * Subscribes to the creation of new consoles. If a new notebook is created, build a new handler for the consoles.
+             * Adds a promise for a instanced handler to the 'handlers' collection.
+             */
+            consoles.widgetAdded.connect(( sender, consolePanel ) => {
+                if (manager.hasHandler(consolePanel.session.path)){
+                    handlers[consolePanel.id] = new Promise(function(resolve, reject) {
+                        resolve(manager.getHandler(consolePanel.session.path));
+                    });
+                }else{
+                    handlers[consolePanel.id] = new Promise( function( resolve, reject ) {
+                        const session = consolePanel.session;
+                        const connector = new KernelConnector( { session } );
+                        
+                        
+                        connector.ready.then(() => { // Create connector and init w script if it exists for kernel type.
+                            let kerneltype: string = connector.kerneltype;
+                        let scripts: Promise<Languages.LanguageModel> = Languages.getScript( kerneltype );
+                        
+                        scripts.then(( result: Languages.LanguageModel ) => {
+                            let initScript = result.initScript;
+                            let queryCommand = result.queryCommand;
+                            let matrixQueryCommand = result.matrixQueryCommand;
+                            
+                            const options: VariableInspectionHandler.IOptions = {
+                                    queryCommand: queryCommand,
+                                    matrixQueryCommand: matrixQueryCommand,
+                                    connector: connector,
+                                    initScript: initScript,
+                                    id: session.path  //Using the sessions path as an identifier for now.
+                            };
+                            const handler = new VariableInspectionHandler( options );
+                            manager.addHandler(handler);
+                            consolePanel.disposed.connect(() => {
+                                delete handlers[consolePanel.id];
+                                handler.dispose();
+                            } );
+                            
+                            handler.ready.then(() => {
+                                resolve( handler );
+                            } );
                         } );
-
-                        handler.ready.then(() => {
-                            resolve( handler );
+                        
+                        
+                        //Otherwise log error message.
+                        scripts.catch(( result: string ) => {
+                            console.log(result);
+                            const handler = new DummyHandler(connector);
+                            consolePanel.disposed.connect(() => {
+                                delete handlers[consolePanel.id];
+                                handler.dispose();
+                            } );
+                            resolve( handler );                        
+                        } )
                         } );
                     } );
-
-
-                    //Otherwise log error message.
-                    scripts.catch(( result: string ) => {
-                        console.log(result);
-                        const handler = new DummyHandler(connector);
-                        consolePanel.disposed.connect(() => {
-                            delete handlers[consolePanel.id];
-                            handler.dispose();
-                        } );
-                        resolve( handler );                        
-                    } )
-                } );
-            } );
-        } );
-
-        /**
-         * If focus window changes, checks whether new focus widget is a console.
-         * In that case, retrieves the handler associated to the console after it has been
-         * initialized and updates the manager with it. 
-         */
-        app.shell.currentChanged.connect(( sender, args ) => {
-            let widget = args.newValue;
-            if ( !widget || !consoles.has( widget ) ) {
-                return;
-            }
-            let future = handlers[widget.id];
-            future.then((source :IVariableInspector.IInspectable ) => {
-                if ( source ) {
-                    manager.source = source;
-                    manager.source.performInspection();               
                 }
-            });
-        } );;
-
-        app.contextMenu.addItem( {
-            command: CommandIDs.open,
-            selector: ".jp-CodeConsole"
-        } );
-
-
-
-    }
+                
+            } );
+            
+            /**
+             * If focus window changes, checks whether new focus widget is a console.
+             * In that case, retrieves the handler associated to the console after it has been
+             * initialized and updates the manager with it. 
+             */
+            app.shell.currentChanged.connect(( sender, args ) => {
+                let widget = args.newValue;
+                if ( !widget || !consoles.has( widget ) ) {
+                    return;
+                }
+                let future = handlers[widget.id];
+                future.then((source :IVariableInspector.IInspectable ) => {
+                    if ( source ) {
+                        manager.source = source;
+                        manager.source.performInspection();               
+                    }
+                });
+            } );;
+            
+            app.contextMenu.addItem( {
+                command: CommandIDs.open,
+                selector: ".jp-CodeConsole"
+            } );
+            
+            
+            
+        }
 }
 
 /**
  * An extension that registers notebooks for variable inspection.
  */
 const notebooks: JupyterLabPlugin<void> = {
-    id: "jupyterlab-extension:variableinspector:notebooks",
-    requires: [IVariableInspector, INotebookTracker],
-    autoStart: true,
-    activate: ( app: JupyterLab, manager: IVariableInspector, notebooks: INotebookTracker ): void => {
-        const handlers: { [id: string]: Promise<VariableInspectionHandler> } = {};
-
-        /**
-         * Subscribes to the creation of new notebooks. If a new notebook is created, build a new handler for the notebook.
-         * Adds a promise for a instanced handler to the 'handlers' collection.
-         */
-        notebooks.widgetAdded.connect(( sender, nbPanel: NotebookPanel ) => {
-
-            //A promise that resolves after the initialization of the handler is done.
-            handlers[nbPanel.id] = new Promise( function( resolve, reject ) {
-
-                const session = nbPanel.session;
-                const connector = new KernelConnector( { session } );
+        id: "jupyterlab-extension:variableinspector:notebooks",
+        requires: [IVariableInspectorManager, INotebookTracker],
+        autoStart: true,
+        activate: ( app: JupyterLab, manager: IVariableInspectorManager, notebooks: INotebookTracker ): void => {
+            const handlers: { [id: string]: Promise<VariableInspectionHandler> } = {};
+            
+            /**
+             * Subscribes to the creation of new notebooks. If a new notebook is created, build a new handler for the notebook.
+             * Adds a promise for a instanced handler to the 'handlers' collection.
+             */
+            notebooks.widgetAdded.connect(( sender, nbPanel: NotebookPanel ) => {
                 
-                connector.ready.then(() => { // Create connector and init w script if it exists for kernel type.
-                    let kerneltype: string = connector.kerneltype;
+                //A promise that resolves after the initialization of the handler is done.
+                handlers[nbPanel.id] = new Promise( function( resolve, reject ) {
+                    
+                    const session = nbPanel.session;
+                    const connector = new KernelConnector( { session } );
+                    
+                    connector.ready.then(() => { // Create connector and init w script if it exists for kernel type.
+                        let kerneltype: string = connector.kerneltype;
                     let scripts: Promise<Languages.LanguageModel> = Languages.getScript( kerneltype );
-                
+                    
                     scripts.then(( result: Languages.LanguageModel ) => {
                         let initScript = result.initScript;
                         let queryCommand = result.queryCommand;
                         let matrixQueryCommand = result.matrixQueryCommand;
-
+                        
                         const options: VariableInspectionHandler.IOptions = {
-                            queryCommand: queryCommand,
-                            matrixQueryCommand: matrixQueryCommand,
-                            connector: connector,
-                            initScript: initScript
+                                queryCommand: queryCommand,
+                                matrixQueryCommand: matrixQueryCommand,
+                                connector: connector,
+                                initScript: initScript,
+                                id: session.path  //Using the sessions path as an identifier for now.
                         };
                         const handler = new VariableInspectionHandler( options );
-
+                        manager.addHandler(handler);
                         nbPanel.disposed.connect(() => {
                             delete handlers[nbPanel.id];
                             handler.dispose();
                         } );
-
+                        
                         handler.ready.then(() => {
                             resolve( handler );
                         } );
                     } );
-
-
+                    
+                    
                     //Otherwise log error message.
                     scripts.catch(( result: string ) => {
                         reject( result );
                     } )
+                    } );
                 } );
             } );
-        } );
-
-        /**
-         * If focus window changes, checks whether new focus widget is a notebook.
-         * In that case, retrieves the handler associated to the notebook after it has been
-         * initialized and updates the manager with it. 
-         */
-        app.shell.currentChanged.connect(( sender, args ) => {
-            let widget = args.newValue;
-            if ( !widget || !notebooks.has( widget ) ) {
-                return;
-            }
-            let future = handlers[widget.id];
-            future.then((source :VariableInspectionHandler ) => {
-                if ( source ) {
-                    manager.source = source;
-                    manager.source.performInspection();               
+            
+            /**
+             * If focus window changes, checks whether new focus widget is a notebook.
+             * In that case, retrieves the handler associated to the notebook after it has been
+             * initialized and updates the manager with it. 
+             */
+            app.shell.currentChanged.connect(( sender, args ) => {
+                let widget = args.newValue;
+                if ( !widget || !notebooks.has( widget ) ) {
+                    return;
                 }
-            });
-        } );
-
-        app.contextMenu.addItem( {
-            command: CommandIDs.open,
-            selector: ".jp-Notebook"
-        } );
-    }
+                let future = handlers[widget.id];
+                future.then((source :VariableInspectionHandler ) => {
+                    if ( source ) {
+                        manager.source = source;
+                        manager.source.performInspection();               
+                    }
+                });
+            } );
+            
+            app.contextMenu.addItem( {
+                command: CommandIDs.open,
+                selector: ".jp-Notebook"
+            } );
+        }
 }
 
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -2,6 +2,24 @@ import {
     VariableInspectorPanel, IVariableInspector
 } from "./variableinspector"
 
+import {
+    Token
+} from '@phosphor/coreutils';
+
+import{
+    VariableInspectionHandler
+}from "./handler";
+
+export const IVariableInspectorManager = new Token<IVariableInspectorManager>("jupyterlab_extension/variableinspector:IVariableInspectorManager" );
+
+export interface IVariableInspectorManager{
+    source: IVariableInspector.IInspectable | null;
+    hasHandler(id:string) : boolean;
+    getHandler(id:string): VariableInspectionHandler;
+    addHandler(handler : VariableInspectionHandler): void;
+    
+}
+
 
 
 /**
@@ -9,11 +27,28 @@ import {
  * `IVariableInspector` instance that other plugins can communicate with.
  */
 export
-    class VariableInspectorManager implements IVariableInspector {
+    class VariableInspectorManager implements IVariableInspectorManager {
 
     private _source: IVariableInspector.IInspectable = null;
     private _panel: VariableInspectorPanel = null;
+    private _handlers : { [id : string] : VariableInspectionHandler} = {};
 
+    public hasHandler(id:string): boolean{
+        if (this._handlers[id]){
+            return true;
+        }else{
+            return false;
+        }
+    }
+   
+    public getHandler(id:string): VariableInspectionHandler{
+        return this._handlers[id];        
+    }
+
+    public addHandler(handler : VariableInspectionHandler){
+        this._handlers[handler.id] = handler;
+    }
+    
     /**
      * The current inspector panel.
      */


### PR DESCRIPTION
Fixes the console spam issue #31 by updating the projects dependencies. 
Note, that jupyterlab version **0.33** or higher is required. (Which can only be installed from source right now)

Additionally, we now reuse existing handlers for a session, e.g, when two notebooks share one kernel they will use the same handler instead of using individual handlers.