### PR TITLE
Fix kernel restart

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -63,16 +63,17 @@ export
         } );
         
         this._connector.kernelRestarted.connect(( sender, kernelReady: Promise<void> ) => {
-            console.log("Restarting connector...")
-            this._ready = new Promise( function( resolve, reject ) {
-                kernelReady.then(() => {
-                    this._initOnKernel().then(( msg: KernelMessage.IExecuteReplyMsg ) => {
-                        this._connector.iopubMessage.connect( this._queryCall );
-                        console.log("Done")
-                        return;
+            
+            const title: IVariableInspector.IVariableTitle = {
+                    contextName: "<b>Restarting kernel...</b> "
+            };
+            this._inspected.emit( <IVariableInspector.IVariableInspectorUpdate>{title : title, payload : []});          
 
-                    } );
-                } );
+            this._ready = kernelReady.then(() => {
+                this._initOnKernel().then(( msg: KernelMessage.IExecuteReplyMsg ) => {
+                    this._connector.iopubMessage.connect( this._queryCall );
+                    this.performInspection();
+                } );         
             } );
         } );
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -62,6 +62,20 @@ export
             } );
         } );
         
+        this._connector.kernelRestarted.connect(( sender, kernelReady: Promise<void> ) => {
+            console.log("Restarting connector...")
+            this._ready = new Promise( function( resolve, reject ) {
+                kernelReady.then(() => {
+                    this._initOnKernel().then(( msg: KernelMessage.IExecuteReplyMsg ) => {
+                        this._connector.iopubMessage.connect( this._queryCall );
+                        console.log("Done")
+                        return;
+
+                    } );
+                } );
+            } );
+        } );
+
     }
 
     get id():string{

--- a/src/kernelconnector.ts
+++ b/src/kernelconnector.ts
@@ -12,7 +12,7 @@ import {
 } from "@jupyterlab/services";
 
 import {
-    ISignal//, Signal, Slot
+    ISignal, Signal//, Slot
 } from "@phosphor/signaling";
 
 
@@ -23,12 +23,24 @@ export
     class KernelConnector {
 
     private _session: IClientSession;
+    private _kernelRestarted = new Signal<this, Promise<void>>(this); 
 
     constructor( options: KernelConnector.IOptions ) {
         this._session = options.session;
+        this._session.statusChanged.connect( (sender, new_status: Kernel.Status) =>{
+            switch (new_status) {
+            	case "restarting":
+            	    //TODO : Check for kernel availability
+            	    return this._session.kernel.ready
+            	default:
+            		break;
+            }
+        });
     }
 
-
+    get kernelRestarted(): ISignal<KernelConnector, Promise<void>>{
+        return this._kernelRestarted
+    }
 
     get kerneltype(): string {
         return this._session.kernel.info.language_info.name;

--- a/src/kernelconnector.ts
+++ b/src/kernelconnector.ts
@@ -31,7 +31,7 @@ export
             switch (new_status) {
             	case "restarting":
             	    //TODO : Check for kernel availability
-            	    return this._session.kernel.ready
+            	    this._kernelRestarted.emit(this._session.kernel.ready);
             	default:
             		break;
             }

--- a/src/variableinspector.ts
+++ b/src/variableinspector.ts
@@ -135,9 +135,13 @@ export
 
         let title = allArgs.title;
         let args = allArgs.payload;
-
-        this._title.innerHTML = "    Inspecting " + title.languageName + "-kernel '"+title.kernelName + "' "+title.contextName;
-
+        
+        if (title.contextName){
+            this._title.innerHTML = title.contextName;            
+        }else{
+            this._title.innerHTML = "    Inspecting " + title.languageName + "-kernel '"+title.kernelName + "' "+title.contextName;
+        }
+        
         //Render new variable state
         let row: HTMLTableRowElement;
         this._table.deleteTFoot();


### PR DESCRIPTION
Fixes #38. Now listens for kernel restart events, clears the inspector table and reinitializes the inspection scripts after successful restart.