### PR TITLE
Fix performance impact from using DataFrames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ package-lock.json
 .project
 .settings
 .ipynb
+.idea
+.iml

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -119,6 +119,10 @@ def _jupyterlab_variableinspector_dict_list():
             return True
         if tf and isinstance(eval(v), tf.Variable):
             return True
+        if pd and pd is not None and (
+            isinstance(eval(v), pd.core.frame.DataFrame)
+            or isinstance(eval(v), pd.core.series.Series)):
+            return True
         if str(eval(v))[0] == "<":
             return False
         if  v in ['np', 'pd', 'pyspark', 'tf']:


### PR DESCRIPTION
Avoids to use the string representation of a dataframe to determine whether an namespace object should be show in the inspector table or not.