### PR TITLE
Fix unicode

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -193,7 +193,8 @@ export
             case "execute_result":
                 let payload = response.content as nbformat.IExecuteResult;
                 let content: string = <string>payload.data["text/plain"];
-                content = content.replace( /^'|'$/g, '' ).replace( /\\"/g, "\"" ).replace( /\\'/g, "\'" );
+                content = content.slice(1,-1);
+                content = content.replace( /\\"/g, "\"" ).replace( /\\'/g, "\'" );
 
                 let update: IVariableInspector.IVariable[];
                 update = <IVariableInspector.IVariable[]>JSON.parse( content );

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -139,7 +139,7 @@ def _jupyterlab_variableinspector_dict_list():
     'varContent': str(_jupyterlab_variableinspector_getcontentof(eval(_v))), 
     'isMatrix': _jupyterlab_variableinspector_is_matrix(eval(_v))}
             for _v in values if keep_cond(_v)]
-    return json.dumps(vardic)
+    return json.dumps(vardic, ensure_ascii=False)
 
 
 def _jupyterlab_variableinspector_getmatrixcontent(x, max_rows=10000):


### PR DESCRIPTION
Allow non-ascii glyphs. Does no longer force ascii encodings in the `json.dumps` method in the python script.