### PR TITLE
Add prepare script to enable installation directly from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ In this early stage you can install this extension by building it from source.
 
 First of all, you need an installation of a current version of JupyterLab. Please refer to the [installation guide](https://github.com/jupyterlab/jupyterlab#installation).
 
+You can install the inspector either by running `jupyter labextension install https://github.com/lckr/jupyterlab-variableInspector`
+
+or by cloning the repository and build it locally following these steps:
+
 
 Next, clone this repository with `git clone https://github.com/lckr/jupyterlab-variableInspector`
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepare": "npm run clean && npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {


### PR DESCRIPTION
I have added a prepare script to enable installation directly from github by running `jupyter labextension install https://github.com/lckr/jupyterlab-variableInspector`.

Your can test it by running `jupyter labextension install https://github.com/elben10/jupyterlab-variableInspector`.