### PR TITLE
Add Binder files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # jupyterlab_variableinspector
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lckr/jupyterlab-variableInspector/master?urlpath=%2Flab)
+
 Jupyterlab extension that shows currently used variables and their values. The goal is to provide a tool similar to the variable inspector in RStudio.
 
 This project is inspired by the [variable inspector extension for jupyter notebooks](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/varInspector) and by the [inspector extension included in jupyterlab](https://github.com/jupyterlab/jupyterlab/tree/master/packages/inspector-extension).

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,7 @@
+name: jupyterlab-variable-inspector
+channels:
+- conda-forge
+dependencies:
+- jupyterlab=1
+- numpy
+- pandas

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,2 @@
+jupyter labextension install @lckr/jupyterlab_variableinspector \
+                             @jupyter-widgets/jupyterlab-manager


### PR DESCRIPTION
Add Binder files so the extension can be tested in a web browser without installing anything locally.

To try it:

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jtpio/jupyterlab-variableInspector/binder?urlpath=%2Flab)