### PR TITLE
mask the import names for less likelihood of conflict

### DIFF
--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -77,7 +77,7 @@ def _check_imported():
         try:
             import ipywidgets as __ipywidgets
         except ImportError:
-        __ipywidgets = None
+            __ipywidgets = None
 
 
 def _jupyterlab_variableinspector_getsizeof(x):


### PR DESCRIPTION
fixes #145, #131, future similar issues

also fails over keras import to `tensorflow.keras` since its part of the TensorFlow package