### PR TITLE
Add the variable inspector to the right area

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,6 @@ const variableinspector: JupyterFrontEndPlugin<IVariableInspectorManager> = {
       const panel = new VariableInspectorPanel();
 
       panel.id = 'jp-variableinspector';
-      panel.title.label = 'Variable Inspector';
       panel.title.icon = listIcon;
       panel.title.closable = true;
       panel.disposed.connect(() => {

--- a/style/index.css
+++ b/style/index.css
@@ -5,6 +5,7 @@
     flex-direction: column;
     overflow: auto;
     font-size: var(--jp-ui-font-size1);
+    background: var(--jp-layout-color1);
   }
   
   .jp-VarInspector-table {


### PR DESCRIPTION
Fixes https://github.com/lckr/jupyterlab-variableInspector/issues/137

As suggested in #137, the right sidebar sounds like a nice place for the variable inspector widget:  

https://user-images.githubusercontent.com/591645/213567372-cb70a6b1-18e8-4af1-98dd-282fa7a3c559.mp4

It's also possible to switch sidebar side if needed:

https://user-images.githubusercontent.com/591645/213567361-78f0d644-038f-4762-a49d-8a0a89bd7902.mp4

### Changes

- [x] Add the variable inspector to the right area by default
- [x] Remove the command to open a new inspector in the `main` area