### PR TITLE
Bump @jupyter/web-components to 0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     },
     "packageManager": "yarn@3.5.0",
     "dependencies": {
-        "@jupyter/web-components": "^0.15.0",
+        "@jupyter/web-components": "^0.16.0",
         "@jupyterlab/application": "^4.0.0",
         "@jupyterlab/apputils": "^4.0.0",
         "@jupyterlab/console": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,15 +485,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/web-components@npm:^0.15.0":
-  version: 0.15.3
-  resolution: "@jupyter/web-components@npm:0.15.3"
+"@jupyter/web-components@npm:^0.16.0":
+  version: 0.16.7
+  resolution: "@jupyter/web-components@npm:0.16.7"
   dependencies:
     "@microsoft/fast-colors": ^5.3.1
     "@microsoft/fast-element": ^1.12.0
     "@microsoft/fast-foundation": ^2.49.4
     "@microsoft/fast-web-utilities": ^5.4.1
-  checksum: a0980af934157bfdbdb6cc169c0816c1b2e57602d524c56bdcef746a4c25dfeb8f505150d83207c8695ed89b5486cf53d35a3382584d25ef64db666e4e16e45b
+  checksum: ec3336247bbabb2e2587c2cf8b9d0e80786b454916dd600b3d6791bf08c3d1e45a7ec1becf366a5491ab56b0be020baa8c50a5b6067961faf5ec904de31243aa
   languageName: node
   linkType: hard
 
@@ -1124,7 +1124,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lckr/jupyterlab_variableinspector@workspace:."
   dependencies:
-    "@jupyter/web-components": ^0.15.0
+    "@jupyter/web-components": ^0.16.0
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/apputils": ^4.0.0
     "@jupyterlab/builder": ^4.0.0


### PR DESCRIPTION
CI is failing due to

```bash
$ jupyter labextension list --verbose
"@lckr/jupyterlab_variableinspector@3.2.4" is not compatible with the current JupyterLab
Conflicting Dependencies:
JupyterLab              Extension        Package
>=0.16.6 <0.17.0        >=0.15.0 <0.16.0 @jupyter/web-components
```
Here I am bumping `@jupyter/web-components` to 0.16 which works for me locally.