### PR TITLE
To compatible with XPython kernel and to render mime properly

### DIFF
--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -27,7 +27,11 @@ from IPython.core.magics.namespace import NamespaceMagics
 
 _jupyterlab_variableinspector_nms = NamespaceMagics()
 _jupyterlab_variableinspector_Jupyter = get_ipython()
-_jupyterlab_variableinspector_nms.shell = _jupyterlab_variableinspector_Jupyter.kernel.shell
+# Check kernel implementation
+if hasattr(_jupyterlab_variableinspector_Jupyter.kernel, 'shell'):
+    _jupyterlab_variableinspector_nms.shell = _jupyterlab_variableinspector_Jupyter.kernel.shell
+else:
+    _jupyterlab_variableinspector_nms.shell = _jupyterlab_variableinspector_Jupyter
 
 _jupyterlab_variableinspector_maxitems = 10
 

--- a/src/variableinspector.ts
+++ b/src/variableinspector.ts
@@ -386,6 +386,9 @@ export class VariableInspectorPanel
       row.appendChild(cell);
 
       cell = document.createElement('jp-data-grid-cell') as DataGridCell;
+      cell.gridColumn = '7';
+      row.appendChild(cell);
+      this._table.appendChild(row);
       const rendermime = this._source?.rendermime;
       if (item.isWidget && rendermime) {
         const model = new OutputAreaModel({ trusted: true });
@@ -398,9 +401,6 @@ export class VariableInspectorPanel
           '</br>'
         );
       }
-      cell.gridColumn = '7';
-      row.appendChild(cell);
-      this._table.appendChild(row);
     }
   }
 


### PR DESCRIPTION
1. Check kernel implementation type before _jupyterlab_variableinspector_nms.shell assignment.
2. Append cell and row elements before to render mime, as isconnected property requires true on some browsers.